### PR TITLE
Native multi-tenancy (FILEX_MULTI_TENANT)

### DIFF
--- a/backend/db/migrations/mysql/00014_multi_tenant.sql
+++ b/backend/db/migrations/mysql/00014_multi_tenant.sql
@@ -1,0 +1,55 @@
+-- +goose Up
+-- Native multi-tenancy — FOUNDATION (schema only; inert until FILEX_MULTI_TENANT=1).
+--
+-- A "provider" is a tenant: an auth realm (OIDC or local) bound to a host and
+-- linked to one or more storages (via provider_storages). Users carry a
+-- provider_id tag. This migration is purely ADDITIVE and backfills a single
+-- "default" provider so every existing user has a home — single-tenant
+-- behaviour is unchanged because nothing reads provider_id while multi-tenant
+-- mode is off. The users email-unique swap to (provider_id, email) lands in a
+-- LATER migration, together with the login/JIT code that needs it.
+-- See docs/MULTI-TENANCY.md.
+
+CREATE TABLE IF NOT EXISTS providers (
+    id                 BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    slug               VARCHAR(191) NOT NULL UNIQUE,
+    name               VARCHAR(255) NOT NULL DEFAULT '',
+    host               VARCHAR(255),
+    auth_type          VARCHAR(16) NOT NULL DEFAULT 'oidc',
+    oidc_issuer        TEXT,
+    oidc_client_id     VARCHAR(255),
+    oidc_client_secret TEXT,
+    oidc_redirect_url  VARCHAR(512),
+    role_claim         VARCHAR(255),
+    admin_group        VARCHAR(255),
+    is_supertenant     TINYINT(1) NOT NULL DEFAULT 0,
+    enabled            TINYINT(1) NOT NULL DEFAULT 1,
+    created_at         DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at         DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    KEY idx_providers_host (host)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS provider_storages (
+    provider_id BIGINT NOT NULL,
+    storage_id  BIGINT NOT NULL,
+    PRIMARY KEY (provider_id, storage_id),
+    CONSTRAINT fk_provider_storages_provider FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE,
+    CONSTRAINT fk_provider_storages_storage  FOREIGN KEY (storage_id)  REFERENCES storages(id)  ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE users ADD COLUMN provider_id BIGINT NULL;
+ALTER TABLE users ADD COLUMN oidc_subject VARCHAR(255) NULL;
+ALTER TABLE users ADD KEY idx_users_provider (provider_id);
+
+-- The original org = the default tenant + platform supertenant (both inert
+-- while single-tenant). Every pre-existing user joins it.
+INSERT INTO providers (slug, name, is_supertenant) VALUES ('default', 'Default', 1);
+UPDATE users SET provider_id = (SELECT id FROM providers WHERE slug = 'default')
+    WHERE provider_id IS NULL;
+
+-- +goose Down
+ALTER TABLE users DROP KEY idx_users_provider;
+ALTER TABLE users DROP COLUMN oidc_subject;
+ALTER TABLE users DROP COLUMN provider_id;
+DROP TABLE IF EXISTS provider_storages;
+DROP TABLE IF EXISTS providers;

--- a/backend/db/migrations/postgres/00014_multi_tenant.sql
+++ b/backend/db/migrations/postgres/00014_multi_tenant.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- Native multi-tenancy — FOUNDATION (schema only; inert until FILEX_MULTI_TENANT=1).
+--
+-- A "provider" is a tenant: an auth realm (OIDC or local) bound to a host and
+-- linked to one or more storages (via provider_storages). Users carry a
+-- provider_id tag. This migration is purely ADDITIVE and backfills a single
+-- "default" provider so every existing user has a home — single-tenant
+-- behaviour is unchanged because nothing reads provider_id while multi-tenant
+-- mode is off. The users email-unique swap to (provider_id, email) lands in a
+-- LATER migration, together with the login/JIT code that needs it.
+-- See docs/MULTI-TENANCY.md.
+
+CREATE TABLE IF NOT EXISTS providers (
+    id                 BIGSERIAL PRIMARY KEY,
+    slug               TEXT NOT NULL UNIQUE,
+    name               TEXT NOT NULL DEFAULT '',
+    host               TEXT,
+    auth_type          TEXT NOT NULL DEFAULT 'oidc',
+    oidc_issuer        TEXT,
+    oidc_client_id     TEXT,
+    oidc_client_secret TEXT,
+    oidc_redirect_url  TEXT,
+    role_claim         TEXT,
+    admin_group        TEXT,
+    is_supertenant     BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled            BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_providers_host ON providers(host);
+
+CREATE TABLE IF NOT EXISTS provider_storages (
+    provider_id BIGINT NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+    storage_id  BIGINT NOT NULL REFERENCES storages(id) ON DELETE CASCADE,
+    PRIMARY KEY (provider_id, storage_id)
+);
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS provider_id BIGINT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS oidc_subject TEXT;
+CREATE INDEX IF NOT EXISTS idx_users_provider ON users(provider_id);
+
+-- The original org = the default tenant + platform supertenant (both inert
+-- while single-tenant). Every pre-existing user joins it.
+INSERT INTO providers (slug, name, is_supertenant) VALUES ('default', 'Default', TRUE);
+UPDATE users SET provider_id = (SELECT id FROM providers WHERE slug = 'default')
+    WHERE provider_id IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_users_provider;
+ALTER TABLE users DROP COLUMN IF EXISTS oidc_subject;
+ALTER TABLE users DROP COLUMN IF EXISTS provider_id;
+DROP TABLE IF EXISTS provider_storages;
+DROP TABLE IF EXISTS providers;

--- a/backend/db/migrations/sqlite/00014_multi_tenant.sql
+++ b/backend/db/migrations/sqlite/00014_multi_tenant.sql
@@ -1,0 +1,54 @@
+-- +goose Up
+-- Native multi-tenancy — FOUNDATION (schema only; inert until FILEX_MULTI_TENANT=1).
+--
+-- A "provider" is a tenant: an auth realm (OIDC or local) bound to a host and
+-- linked to one or more storages (via provider_storages). Users carry a
+-- provider_id tag. This migration is purely ADDITIVE and backfills a single
+-- "default" provider so every existing user has a home — single-tenant
+-- behaviour is unchanged because nothing reads provider_id while multi-tenant
+-- mode is off. The users email-unique swap to (provider_id, email) lands in a
+-- LATER migration, together with the login/JIT code that needs it, so this one
+-- stays non-destructive and portable across all three dialects.
+-- See docs/MULTI-TENANCY.md.
+
+CREATE TABLE IF NOT EXISTS providers (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug               TEXT NOT NULL UNIQUE,
+    name               TEXT NOT NULL DEFAULT '',
+    host               TEXT,
+    auth_type          TEXT NOT NULL DEFAULT 'oidc',
+    oidc_issuer        TEXT,
+    oidc_client_id     TEXT,
+    oidc_client_secret TEXT,
+    oidc_redirect_url  TEXT,
+    role_claim         TEXT,
+    admin_group        TEXT,
+    is_supertenant     INTEGER NOT NULL DEFAULT 0,
+    enabled            INTEGER NOT NULL DEFAULT 1,
+    created_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_providers_host ON providers(host);
+
+CREATE TABLE IF NOT EXISTS provider_storages (
+    provider_id INTEGER NOT NULL REFERENCES providers(id) ON DELETE CASCADE,
+    storage_id  INTEGER NOT NULL REFERENCES storages(id) ON DELETE CASCADE,
+    PRIMARY KEY (provider_id, storage_id)
+);
+
+ALTER TABLE users ADD COLUMN provider_id INTEGER;
+ALTER TABLE users ADD COLUMN oidc_subject TEXT;
+CREATE INDEX IF NOT EXISTS idx_users_provider ON users(provider_id);
+
+-- The original org = the default tenant + platform supertenant (both inert
+-- while single-tenant). Every pre-existing user joins it.
+INSERT INTO providers (slug, name, is_supertenant) VALUES ('default', 'Default', 1);
+UPDATE users SET provider_id = (SELECT id FROM providers WHERE slug = 'default')
+    WHERE provider_id IS NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_users_provider;
+ALTER TABLE users DROP COLUMN oidc_subject;
+ALTER TABLE users DROP COLUMN provider_id;
+DROP TABLE IF EXISTS provider_storages;
+DROP TABLE IF EXISTS providers;

--- a/backend/internal/api/handlers/audit.go
+++ b/backend/internal/api/handlers/audit.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 )
 
 // Audit handles /api/admin/audit.
@@ -64,6 +65,25 @@ func (h *Audit) List(w http.ResponseWriter, r *http.Request) {
 	}
 	if entries == nil {
 		entries = []*db.AuditEntryWithUser{}
+	}
+	// Multi-tenant: a tenant-admin only sees its own users' audit trail
+	// (docs/MULTI-TENANCY.md §9). System entries (no user) stay
+	// supertenant-only. Total is recomputed from the filtered page.
+	if scope, ok := tenant.FromContext(ctx); ok && !scope.IsSupertenant {
+		allowed := map[int64]bool{}
+		if users, err := h.Store.ListUsersByProvider(ctx, scope.ProviderID); err == nil {
+			for _, u := range users {
+				allowed[u.ID] = true
+			}
+		}
+		kept := entries[:0]
+		for _, e := range entries {
+			if e.Entry != nil && e.Entry.UserID != nil && allowed[*e.Entry.UserID] {
+				kept = append(kept, e)
+			}
+		}
+		entries = kept
+		total = int64(len(entries))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"entries": entries,

--- a/backend/internal/api/handlers/auth.go
+++ b/backend/internal/api/handlers/auth.go
@@ -13,15 +13,16 @@ import (
 
 // Auth handles login/logout/oidc routes.
 type Auth struct {
-	Store     db.Store
-	LocalAuth auth.LoginDriver
-	OIDCAuth  auth.OIDCDriver
-	PublicURL string
+	Store       db.Store
+	LocalAuth   auth.LoginDriver
+	OIDCAuth    auth.OIDCDriver
+	PublicURL   string
+	MultiTenant bool
 }
 
 // NewAuth constructs an Auth handler.
-func NewAuth(store db.Store, local auth.LoginDriver, oidc auth.OIDCDriver, publicURL string) *Auth {
-	return &Auth{Store: store, LocalAuth: local, OIDCAuth: oidc, PublicURL: publicURL}
+func NewAuth(store db.Store, local auth.LoginDriver, oidc auth.OIDCDriver, publicURL string, multiTenant bool) *Auth {
+	return &Auth{Store: store, LocalAuth: local, OIDCAuth: oidc, PublicURL: publicURL, MultiTenant: multiTenant}
 }
 
 type loginReq struct {
@@ -54,6 +55,16 @@ func (h *Auth) Login(w http.ResponseWriter, r *http.Request) {
 	user, token, err := h.LocalAuth.Login(r.Context(), req.Email, req.Password)
 	if err != nil {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
+		return
+	}
+	if !auth.LoginAllowed(r.Context(), h.Store, h.MultiTenant, user) {
+		// Maintenance mode: multi-tenant is off but tenants exist — only the
+		// supertenant may sign in. See docs/MULTI-TENANCY.md.
+		_ = h.Store.DeleteSession(r.Context(), token)
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"error":       "sign-in is temporarily limited to the platform operator",
+			"maintenance": true,
+		})
 		return
 	}
 	if user.TOTPEnabled {
@@ -107,9 +118,15 @@ func (h *Auth) OIDCCallback(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "OIDC not configured"})
 		return
 	}
-	_, token, err := h.OIDCAuth.HandleCallback(w, r)
+	usr, token, err := h.OIDCAuth.HandleCallback(w, r)
 	if err != nil {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": err.Error()})
+		return
+	}
+	if !auth.LoginAllowed(r.Context(), h.Store, h.MultiTenant, usr) {
+		// Maintenance mode (see docs/MULTI-TENANCY.md): tenant locked out.
+		_ = h.Store.DeleteSession(r.Context(), token)
+		http.Redirect(w, r, h.PublicURL+"/admin/login?maintenance=1", http.StatusFound)
 		return
 	}
 	setSessionCookie(w, token)

--- a/backend/internal/api/handlers/capabilities.go
+++ b/backend/internal/api/handlers/capabilities.go
@@ -4,17 +4,25 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/brf-tech/filex/backend/internal/auth/drivers/multioidc"
 	"github.com/brf-tech/filex/backend/internal/capability"
+	"github.com/brf-tech/filex/backend/internal/db"
 )
 
 // Capabilities exposes /api/capabilities.
 type Capabilities struct {
 	Service *capability.Service
+	// Store + MultiTenant power the per-tenant branding block: in multi-tenant
+	// mode the (pre-auth, host-resolved) capabilities answer carries only THIS
+	// host's tenant identity — never the existence of other tenants
+	// (docs/MULTI-TENANCY.md §12 + isolation checklist).
+	Store       db.Store
+	MultiTenant bool
 }
 
 // NewCapabilities constructs a Capabilities handler.
-func NewCapabilities(svc *capability.Service) *Capabilities {
-	return &Capabilities{Service: svc}
+func NewCapabilities(svc *capability.Service, store db.Store, multiTenant bool) *Capabilities {
+	return &Capabilities{Service: svc, Store: store, MultiTenant: multiTenant}
 }
 
 // Get returns the runtime feature snapshot.
@@ -71,6 +79,13 @@ func (h *Capabilities) Get(w http.ResponseWriter, r *http.Request) {
 		// Don't clobber an existing nested field of the same name.
 		if _, exists := merged[k]; !exists {
 			merged[k] = v
+		}
+	}
+
+	// Per-tenant branding: identify only the tenant this host belongs to.
+	if h.MultiTenant && h.Store != nil {
+		if p, _ := h.Store.GetProviderByHost(r.Context(), multioidc.RequestHost(r)); p != nil {
+			merged["tenant"] = map[string]any{"slug": p.Slug, "name": p.Name}
 		}
 	}
 	writeJSON(w, http.StatusOK, merged)

--- a/backend/internal/api/handlers/grants.go
+++ b/backend/internal/api/handlers/grants.go
@@ -17,6 +17,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/mailer"
 	"github.com/brf-tech/filex/backend/internal/model"
 	"github.com/brf-tech/filex/backend/internal/share"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 )
 
 // Grants is the per-file/per-folder permission-management API backing the
@@ -350,10 +351,16 @@ func (h *Grants) AdminList(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	// Multi-tenant: a tenant-admin only sees grants on its own storages
+	// (docs/MULTI-TENANCY.md §9).
+	scope, scoped := tenant.FromContext(r.Context())
 	storageName := map[int64]string{}
 	userEmail := map[int64]string{}
 	out := make([]map[string]any, 0, len(all))
 	for _, g := range all {
+		if scoped && !scope.IsSupertenant && !scope.CanAccessStorage(g.StorageID) {
+			continue
+		}
 		if _, ok := storageName[g.StorageID]; !ok {
 			if st, e := h.Store.GetStorage(r.Context(), g.StorageID); e == nil && st != nil {
 				storageName[g.StorageID] = st.Name

--- a/backend/internal/api/handlers/providers.go
+++ b/backend/internal/api/handlers/providers.go
@@ -1,0 +1,318 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/tenant"
+)
+
+// Providers handles /api/admin/providers — the tenant lifecycle API
+// (docs/MULTI-TENANCY.md §8, §11): create/suspend/delete tenants, link
+// storages, transfer the supertenant flag.
+//
+// Guards enforced here (not scattered):
+//   - only a supertenant admin may manage providers in multi-tenant mode;
+//   - at most ONE supertenant — setting the flag on another provider is a
+//     TRANSFER (the old supertenant becomes a regular tenant atomically);
+//   - the supertenant cannot be deleted, disabled, or directly un-flagged;
+//   - deleting a tenant with users requires ?force=1 and then cascades its
+//     users and storage LINKS. Storage rows and file data are never touched —
+//     unlinking is reversible, deleting files is not.
+type Providers struct {
+	Store       db.Store
+	MultiTenant bool
+}
+
+// NewProviders constructs the handler.
+func NewProviders(store db.Store, multiTenant bool) *Providers {
+	return &Providers{Store: store, MultiTenant: multiTenant}
+}
+
+// requireSupertenant gates management: in multi-tenant mode only the
+// supertenant's admins pass (the route group already requires admin); in
+// single-tenant mode every admin passes (no scope is set).
+func (h *Providers) requireSupertenant(w http.ResponseWriter, r *http.Request) bool {
+	if scope, ok := tenant.FromContext(r.Context()); ok && !scope.IsSupertenant {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "only the platform operator may manage tenants"})
+		return false
+	}
+	return true
+}
+
+type providerReq struct {
+	Slug             *string `json:"slug"`
+	Name             *string `json:"name"`
+	Host             *string `json:"host"`
+	AuthType         *string `json:"auth_type"`
+	OIDCIssuer       *string `json:"oidc_issuer"`
+	OIDCClientID     *string `json:"oidc_client_id"`
+	OIDCClientSecret *string `json:"oidc_client_secret"`
+	OIDCRedirectURL  *string `json:"oidc_redirect_url"`
+	RoleClaim        *string `json:"role_claim"`
+	AdminGroup       *string `json:"admin_group"`
+	IsSupertenant    *bool   `json:"is_supertenant"`
+	Enabled          *bool   `json:"enabled"`
+}
+
+func (req *providerReq) apply(p *model.Provider) {
+	set := func(dst *string, src *string) {
+		if src != nil {
+			*dst = strings.TrimSpace(*src)
+		}
+	}
+	set(&p.Slug, req.Slug)
+	set(&p.Name, req.Name)
+	set(&p.Host, req.Host)
+	set(&p.AuthType, req.AuthType)
+	set(&p.OIDCIssuer, req.OIDCIssuer)
+	set(&p.OIDCClientID, req.OIDCClientID)
+	set(&p.OIDCRedirectURL, req.OIDCRedirectURL)
+	set(&p.RoleClaim, req.RoleClaim)
+	set(&p.AdminGroup, req.AdminGroup)
+	if req.OIDCClientSecret != nil && *req.OIDCClientSecret != "" {
+		// Empty secret in the payload means "keep the stored one" so the UI can
+		// round-trip the (never-serialized) secret without re-entering it.
+		p.OIDCClientSecret = *req.OIDCClientSecret
+	}
+	if req.Enabled != nil {
+		p.Enabled = *req.Enabled
+	}
+}
+
+type providerOut struct {
+	*model.Provider
+	StorageIDs []int64 `json:"storage_ids"`
+	UserCount  int     `json:"user_count"`
+}
+
+func (h *Providers) out(r *http.Request, p *model.Provider) providerOut {
+	o := providerOut{Provider: p}
+	o.StorageIDs, _ = h.Store.ListProviderStorageIDs(r.Context(), p.ID)
+	if users, err := h.Store.ListUsersByProvider(r.Context(), p.ID); err == nil {
+		o.UserCount = len(users)
+	}
+	return o
+}
+
+// List returns every provider (tenant) with its storage links + user count.
+func (h *Providers) List(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSupertenant(w, r) {
+		return
+	}
+	list, err := h.Store.ListProviders(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	out := make([]providerOut, 0, len(list))
+	for _, p := range list {
+		out = append(out, h.out(r, p))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"providers": out, "multi_tenant": h.MultiTenant})
+}
+
+// Create provisions a tenant.
+func (h *Providers) Create(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSupertenant(w, r) {
+		return
+	}
+	var req providerReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad json"})
+		return
+	}
+	p := &model.Provider{AuthType: model.AuthTypeOIDC, Enabled: true}
+	req.apply(p)
+	if p.Slug == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "slug required"})
+		return
+	}
+	created, err := h.Store.CreateProvider(r.Context(), p)
+	if err != nil {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.IsSupertenant != nil && *req.IsSupertenant {
+		if err := h.transferSupertenant(r, created); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+	fresh, _ := h.Store.GetProvider(r.Context(), created.ID)
+	if fresh == nil {
+		fresh = created
+	}
+	writeJSON(w, http.StatusCreated, h.out(r, fresh))
+}
+
+// Update edits a tenant; flag changes go through the transfer guard.
+func (h *Providers) Update(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSupertenant(w, r) {
+		return
+	}
+	p := h.load(w, r)
+	if p == nil {
+		return
+	}
+	var req providerReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad json"})
+		return
+	}
+	if p.IsSupertenant {
+		if req.IsSupertenant != nil && !*req.IsSupertenant {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot un-flag the supertenant — transfer it by setting is_supertenant on another provider"})
+			return
+		}
+		if req.Enabled != nil && !*req.Enabled {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot disable the supertenant"})
+			return
+		}
+	}
+	req.apply(p)
+	if err := h.Store.UpdateProvider(r.Context(), p); err != nil {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.IsSupertenant != nil && *req.IsSupertenant && !p.IsSupertenant {
+		if err := h.transferSupertenant(r, p); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+	fresh, _ := h.Store.GetProvider(r.Context(), p.ID)
+	if fresh == nil {
+		fresh = p
+	}
+	writeJSON(w, http.StatusOK, h.out(r, fresh))
+}
+
+// transferSupertenant moves the platform flag to p, un-flagging the previous
+// holder — the only way the flag moves, preserving the at-most-one invariant.
+func (h *Providers) transferSupertenant(r *http.Request, p *model.Provider) error {
+	prev, err := h.Store.GetSupertenant(r.Context())
+	if err != nil {
+		return err
+	}
+	if prev != nil && prev.ID != p.ID {
+		prev.IsSupertenant = false
+		if err := h.Store.UpdateProvider(r.Context(), prev); err != nil {
+			return err
+		}
+	}
+	p.IsSupertenant = true
+	return h.Store.UpdateProvider(r.Context(), p)
+}
+
+// Delete removes a tenant. Users require ?force=1 (then cascade); storage
+// LINKS are removed but storage rows + file data are never touched.
+func (h *Providers) Delete(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSupertenant(w, r) {
+		return
+	}
+	p := h.load(w, r)
+	if p == nil {
+		return
+	}
+	if p.IsSupertenant {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot delete the supertenant"})
+		return
+	}
+	users, err := h.Store.ListUsersByProvider(r.Context(), p.ID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if len(users) > 0 && r.URL.Query().Get("force") != "1" {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":      "tenant still has users — pass ?force=1 to delete them too",
+			"user_count": len(users),
+		})
+		return
+	}
+	for _, u := range users {
+		if err := h.Store.DeleteUser(r.Context(), u.ID); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+	ids, _ := h.Store.ListProviderStorageIDs(r.Context(), p.ID)
+	for _, sid := range ids {
+		_ = h.Store.UnlinkProviderStorage(r.Context(), p.ID, sid)
+	}
+	if err := h.Store.DeleteProvider(r.Context(), p.ID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "deleted_users": len(users)})
+}
+
+// LinkStorage links a storage to the tenant (POST {storage_id}).
+func (h *Providers) LinkStorage(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSupertenant(w, r) {
+		return
+	}
+	p := h.load(w, r)
+	if p == nil {
+		return
+	}
+	var req struct {
+		StorageID int64 `json:"storage_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.StorageID == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "storage_id required"})
+		return
+	}
+	if _, err := h.Store.GetStorage(r.Context(), req.StorageID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown storage"})
+		return
+	}
+	if err := h.Store.LinkProviderStorage(r.Context(), p.ID, req.StorageID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, h.out(r, p))
+}
+
+// UnlinkStorage removes a storage link (never the storage itself).
+func (h *Providers) UnlinkStorage(w http.ResponseWriter, r *http.Request) {
+	if !h.requireSupertenant(w, r) {
+		return
+	}
+	p := h.load(w, r)
+	if p == nil {
+		return
+	}
+	sid, err := strconv.ParseInt(chi.URLParam(r, "storageID"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad storage id"})
+		return
+	}
+	if err := h.Store.UnlinkProviderStorage(r.Context(), p.ID, sid); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, h.out(r, p))
+}
+
+// load parses {id} and fetches the provider (writing the error response).
+func (h *Providers) load(w http.ResponseWriter, r *http.Request) *model.Provider {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad id"})
+		return nil
+	}
+	p, err := h.Store.GetProvider(r.Context(), id)
+	if err != nil || p == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
+		return nil
+	}
+	return p
+}

--- a/backend/internal/api/handlers/providers_test.go
+++ b/backend/internal/api/handlers/providers_test.go
@@ -1,0 +1,129 @@
+package handlers_test
+
+// Tenant lifecycle API tests (docs/MULTI-TENANCY.md §11): CRUD over the real
+// router + the supertenant guards (transfer-only flag moves, undeletable /
+// undisablable supertenant, force-cascade) + the multi-tenant management gate.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/api/handlers"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/tenant"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+func TestProviders_LifecycleAndGuards(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	email, pass := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, pass)
+
+	do := func(method, path string, body any) (*http.Response, map[string]any) {
+		t.Helper()
+		var rd *bytes.Reader
+		if body != nil {
+			b, _ := json.Marshal(body)
+			rd = bytes.NewReader(b)
+		} else {
+			rd = bytes.NewReader(nil)
+		}
+		req, err := http.NewRequest(method, srv.URL+path, rd)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		out := map[string]any{}
+		_ = json.NewDecoder(resp.Body).Decode(&out)
+		return resp, out
+	}
+
+	// Create a tenant.
+	resp, acme := do("POST", "/api/admin/providers", map[string]any{"slug": "acme", "host": "files.acme.test"})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	acmeID := int64(acme["id"].(float64))
+
+	// Transfer the supertenant flag to a new provider — at most one must hold it.
+	resp, beta := do("POST", "/api/admin/providers", map[string]any{"slug": "beta", "is_supertenant": true})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	betaID := int64(beta["id"].(float64))
+	assert.True(t, beta["is_supertenant"].(bool))
+
+	resp, list := do("GET", "/api/admin/providers", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	supers := 0
+	for _, it := range list["providers"].([]any) {
+		if it.(map[string]any)["is_supertenant"].(bool) {
+			supers++
+		}
+	}
+	assert.Equal(t, 1, supers, "at most one supertenant (transfer semantics)")
+
+	// The supertenant can be neither un-flagged, disabled nor deleted.
+	resp, _ = do("PATCH", "/api/admin/providers/"+itoa(betaID), map[string]any{"is_supertenant": false})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp, _ = do("PATCH", "/api/admin/providers/"+itoa(betaID), map[string]any{"enabled": false})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp, _ = do("DELETE", "/api/admin/providers/"+itoa(betaID), nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// Storage link / unlink (links only — storages are never deleted here).
+	st, err := store.CreateStorage(context.Background(), &model.Storage{
+		Name: "acme-files", Driver: "local", MountPath: "/",
+		ConfigJSON: []byte(`{"path":"/tmp/acme"}`),
+		SyncMode:   model.SyncModePoll, SyncIntervalS: 900, Enabled: true,
+	})
+	require.NoError(t, err)
+	resp, out := do("POST", "/api/admin/providers/"+itoa(acmeID)+"/storages", map[string]any{"storage_id": st.ID})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Len(t, out["storage_ids"], 1)
+	resp, out = do("DELETE", "/api/admin/providers/"+itoa(acmeID)+"/storages/"+itoa(st.ID), nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, out["storage_ids"])
+
+	// Delete with users: refused without force, cascades with it.
+	u, err := store.CreateUser(context.Background(), "worker@acme.test", "", model.RoleUser, "en", "UTC")
+	require.NoError(t, err)
+	require.NoError(t, store.SetUserProvider(context.Background(), u.ID, acmeID, ""))
+	resp, out = do("DELETE", "/api/admin/providers/"+itoa(acmeID), nil)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	assert.EqualValues(t, 1, out["user_count"])
+	resp, out = do("DELETE", "/api/admin/providers/"+itoa(acmeID)+"?force=1", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.EqualValues(t, 1, out["deleted_users"])
+	gone, err := store.GetUserByProviderEmail(context.Background(), acmeID, "worker@acme.test")
+	require.NoError(t, err)
+	assert.Nil(t, gone, "tenant user cascaded")
+}
+
+// TestProviders_TenantAdminForbidden — in multi-tenant mode only the
+// supertenant's admins manage tenants; a tenant-admin gets 403.
+func TestProviders_TenantAdminForbidden(t *testing.T) {
+	_, store := testutil.NewTestDB(t)
+	h := handlers.NewProviders(store, true)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/providers", nil)
+	req = req.WithContext(tenant.WithScope(req.Context(), &tenant.Scope{ProviderID: 42}))
+	h.List(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/admin/providers", nil)
+	req = req.WithContext(tenant.WithScope(req.Context(), &tenant.Scope{ProviderID: 1, IsSupertenant: true}))
+	h.List(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func itoa(v int64) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/backend/internal/api/handlers/search.go
+++ b/backend/internal/api/handlers/search.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/db"
 	"github.com/brf-tech/filex/backend/internal/model"
 	"github.com/brf-tech/filex/backend/internal/search"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 )
 
 // Search handles /api/files/search.
@@ -86,6 +87,19 @@ func (h *Search) Search(w http.ResponseWriter, r *http.Request) {
 			results = fallback
 		}
 	}
+	// Multi-tenant: drop hits in storages outside the caller's tenant. This is
+	// the file-data (layer-1) confinement — an unfiltered search is the classic
+	// cross-tenant leak (content, not just a name). No-op unless a scope is set.
+	if scope, ok := tenant.FromContext(r.Context()); ok {
+		kept := results[:0]
+		for _, n := range results {
+			if scope.CanAccessStorage(n.StorageID) {
+				kept = append(kept, n)
+			}
+		}
+		results = kept
+	}
+
 	// RBAC: drop hits the caller can't see (per-storage grants; cached).
 	if h.ACL != nil {
 		user := auth.UserFrom(r.Context())

--- a/backend/internal/api/handlers/shares_admin.go
+++ b/backend/internal/api/handlers/shares_admin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 )
 
 // SharesAdmin handles /api/admin/shares.
@@ -53,6 +54,28 @@ func (h *SharesAdmin) List(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+	// Multi-tenant: a tenant-admin only sees shares on its own storages
+	// (docs/MULTI-TENANCY.md §9). The scoped store's ListStorages is already
+	// tenant-confined, so its name set IS the allowed set; a row without a
+	// resolvable storage name stays hidden (fail closed). Total is recomputed
+	// from the filtered page — approximate across pages, acceptable for a
+	// name-level admin view.
+	if scope, ok := tenant.FromContext(r.Context()); ok && !scope.IsSupertenant {
+		allowed := map[string]bool{}
+		if sts, err := h.Store.ListStorages(r.Context()); err == nil {
+			for _, st := range sts {
+				allowed[st.Name] = true
+			}
+		}
+		kept := rows[:0]
+		for _, row := range rows {
+			if row.StorageName != "" && allowed[row.StorageName] {
+				kept = append(kept, row)
+			}
+		}
+		rows = kept
+		total = int64(len(rows))
 	}
 	// Dual envelope: `items/total/page/page_size` is what the admin
 	// SPA expects (PaginatedResponse); `entries/limit/offset` keeps

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -125,12 +125,13 @@ func BuildRouter(d *Deps) http.Handler {
 	ooh := handlers.NewOnlyOffice(d.OnlyOffice, d.Store, d.StorageResolver)
 	ooh.AttachACL(d.ACL)
 	th := handlers.NewThumb(d.Store, d.Thumbs)
-	ch := handlers.NewCapabilities(d.Caps)
+	ch := handlers.NewCapabilities(d.Caps, d.Store, d.Cfg.MultiTenant)
 	stg := handlers.NewStorages(d.Store, d.Worker)
 	ush := handlers.NewUsers(d.Store)
 	seth := handlers.NewSettings(d.Store)
 	seth.AttachMailer(d.Mailer)
-	authh := handlers.NewAuth(d.Store, d.LocalAuth, d.OIDCAuth, d.Cfg.PublicURL)
+	authh := handlers.NewAuth(d.Store, d.LocalAuth, d.OIDCAuth, d.Cfg.PublicURL, d.Cfg.MultiTenant)
+	provH := handlers.NewProviders(d.Store, d.Cfg.MultiTenant)
 	sxh := handlers.NewSearch(d.Index, d.Store)
 	sxh.AttachACL(d.ACL)
 
@@ -208,6 +209,9 @@ func BuildRouter(d *Deps) http.Handler {
 		// API token (host apps proxying the embedded explorer). Token absent →
 		// falls through to the session chain, so existing auth is unchanged.
 		r.Use(auth.MiddlewareWithToken(d.Store, true))
+		// Resolve the tenant (provider) scope from the user (no-op unless
+		// multi-tenant mode is on). See docs/MULTI-TENANCY.md.
+		r.Use(auth.TenantResolver(d.Store, d.Cfg.MultiTenant))
 		// Audit curated self-service + file mutations (profile, password,
 		// TOTP, shares, file deletes — shouldAudit() filters the rest).
 		r.Use(auth.AuditMiddleware(d.Store))
@@ -336,6 +340,10 @@ func BuildRouter(d *Deps) http.Handler {
 	r.Group(func(r chi.Router) {
 		r.Use(auth.Middleware(true))
 		r.Use(auth.RequireAdmin)
+		// Scope admin to its tenant (no-op unless multi-tenant mode is on). A
+		// tenant-admin then only sees its own storages/users; the supertenant
+		// sees all. See docs/MULTI-TENANCY.md.
+		r.Use(auth.TenantResolver(d.Store, d.Cfg.MultiTenant))
 		// Record every successful mutating admin action. The middleware is
 		// otherwise defined but never installed anywhere, which left the
 		// Audit page empty even after real changes.
@@ -381,6 +389,17 @@ func BuildRouter(d *Deps) http.Handler {
 				r.Patch("/", seth.Update)
 				r.Post("/smtp-test", seth.SMTPTest)
 				r.Put("/{key}", seth.Set)
+			})
+
+			// Tenant lifecycle (multi-tenancy). In multi-tenant mode only the
+			// supertenant's admins pass the handler's internal gate.
+			r.Route("/providers", func(r chi.Router) {
+				r.Get("/", provH.List)
+				r.Post("/", provH.Create)
+				r.Patch("/{id}", provH.Update)
+				r.Delete("/{id}", provH.Delete)
+				r.Post("/{id}/storages", provH.LinkStorage)
+				r.Delete("/{id}/storages/{storageID}", provH.UnlinkStorage)
 			})
 
 			// AI / MCP / FilexClient bearer tokens. POST returns the
@@ -479,7 +498,7 @@ func BuildRouter(d *Deps) http.Handler {
 	})
 
 	// ────── AI / MCP (token-authenticated) ──────
-	// Token-only namespace consumed by AI agents, the work.example.com
+	// Token-only namespace consumed by AI agents, the work.brf.sh
 	// FilexClient, and MCP clients. auth.APITokenMiddleware validates
 	// X-Filex-Token / Bearer and attaches the bound principal + token;
 	// RequireScope gates verbs (read/write/delete/mcp). A token with no
@@ -502,6 +521,9 @@ func BuildRouter(d *Deps) http.Handler {
 	aiMCP.AttachACL(d.ACL)
 	r.Route("/api/ai", func(r chi.Router) {
 		r.Use(auth.APITokenMiddleware(d.Store))
+		// Agents are tenant-scoped too — resolve the token user's provider
+		// (no-op unless multi-tenant mode is on). See docs/MULTI-TENANCY.md.
+		r.Use(auth.TenantResolver(d.Store, d.Cfg.MultiTenant))
 
 		// Discovery: any valid token may learn its confinement root + reachable
 		// storages (no verb scope needed) so a confined agent stops guessing.

--- a/backend/internal/auth/drivers/multioidc/multioidc.go
+++ b/backend/internal/auth/drivers/multioidc/multioidc.go
@@ -1,0 +1,123 @@
+// Package multioidc dispatches OIDC flows to per-tenant IdP realms
+// (docs/MULTI-TENANCY.md §5,§7).
+//
+// In multi-tenant mode each provider row may carry its own OIDC config
+// (issuer/client/secret — e.g. one Keycloak realm per tenant, each on its own
+// host). The dispatcher resolves the request Host → provider → a lazily
+// initialised, cached oidc.Driver pinned to that provider (SetProviderID), so
+// the JIT upsert stamps users with the right tenant. Hosts that resolve to no
+// provider — or to a provider without OIDC config — fall back to the
+// config-file driver (the single-tenant/supertenant realm), so the flag being
+// on never breaks the operator's own login.
+//
+// The OIDC callback arrives on the same host that started the flow (each
+// tenant's redirect URL lives on its own host), so StartFlow and
+// HandleCallback resolve to the same provider by construction.
+package multioidc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/brf-tech/filex/backend/internal/auth"
+	authoidc "github.com/brf-tech/filex/backend/internal/auth/drivers/oidc"
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
+)
+
+// Dispatcher implements auth.OIDCDriver over N per-tenant realms.
+type Dispatcher struct {
+	store    db.Store
+	fallback auth.OIDCDriver // config-file driver (may be nil)
+
+	mu    sync.Mutex
+	cache map[int64]*entry
+}
+
+type entry struct {
+	drv  *authoidc.Driver
+	hash string // config fingerprint; re-init when the provider row changes
+}
+
+// New wraps the config-file OIDC driver (may be nil) with per-tenant dispatch.
+func New(store db.Store, fallback auth.OIDCDriver) *Dispatcher {
+	return &Dispatcher{store: store, fallback: fallback, cache: map[int64]*entry{}}
+}
+
+// StartFlow implements auth.OIDCDriver.
+func (m *Dispatcher) StartFlow(w http.ResponseWriter, r *http.Request) error {
+	drv, err := m.resolve(r)
+	if err != nil {
+		return err
+	}
+	return drv.StartFlow(w, r)
+}
+
+// HandleCallback implements auth.OIDCDriver.
+func (m *Dispatcher) HandleCallback(w http.ResponseWriter, r *http.Request) (*model.User, string, error) {
+	drv, err := m.resolve(r)
+	if err != nil {
+		return nil, "", err
+	}
+	return drv.HandleCallback(w, r)
+}
+
+// resolve maps the request host to a tenant OIDC driver, or the fallback.
+func (m *Dispatcher) resolve(r *http.Request) (auth.OIDCDriver, error) {
+	p, _ := m.store.GetProviderByHost(r.Context(), RequestHost(r))
+	if p == nil || p.AuthType != model.AuthTypeOIDC || p.OIDCIssuer == "" || p.OIDCClientID == "" {
+		if m.fallback == nil {
+			return nil, errors.New("oidc: no identity provider for this host")
+		}
+		return m.fallback, nil
+	}
+	return m.driverFor(r.Context(), p, RequestHost(r))
+}
+
+// driverFor returns the cached driver for p, (re)initialising it when the
+// provider row changed. Discovery runs once per provider per config version.
+func (m *Dispatcher) driverFor(ctx context.Context, p *model.Provider, host string) (auth.OIDCDriver, error) {
+	redirect := p.OIDCRedirectURL
+	if redirect == "" {
+		// Each tenant lives on its own host; default the redirect there. TLS is
+		// assumed — multi-tenant hosts sit behind the reverse proxy that
+		// terminates HTTPS (see docs/MULTI-TENANCY.md §13).
+		redirect = "https://" + host + "/api/auth/oidc/callback"
+	}
+	hash := strings.Join([]string{p.OIDCIssuer, p.OIDCClientID, p.OIDCClientSecret, redirect, p.RoleClaim, p.AdminGroup}, "\x00")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.cache[p.ID]; ok && e.hash == hash {
+		return e.drv, nil
+	}
+	drv := authoidc.New(m.store)
+	if err := drv.Init(ctx, map[string]any{
+		"issuer":        p.OIDCIssuer,
+		"client_id":     p.OIDCClientID,
+		"client_secret": p.OIDCClientSecret,
+		"redirect_url":  redirect,
+		"role_claim":    p.RoleClaim,
+		"admin_group":   p.AdminGroup,
+	}); err != nil {
+		return nil, err
+	}
+	drv.SetProviderID(p.ID)
+	m.cache[p.ID] = &entry{drv: drv, hash: hash}
+	return drv, nil
+}
+
+// RequestHost extracts the bare hostname (no port) the client asked for.
+// Behind the reverse proxy filex trusts the proxied Host header (the proxy is
+// the only reachable path in the documented deployments — §13 trusted-host).
+func RequestHost(r *http.Request) string {
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.ToLower(host)
+}

--- a/backend/internal/auth/drivers/oidc/oidc.go
+++ b/backend/internal/auth/drivers/oidc/oidc.go
@@ -44,6 +44,18 @@ type Driver struct {
 	roleClaim   string // metadata field name containing role
 	adminGroup  string // group/role string that elevates user to admin
 	defaultRole string
+	// providerID scopes this driver instance to one tenant (multi-tenant mode;
+	// docs/MULTI-TENANCY.md): the JIT upsert then looks users up WITHIN that
+	// provider and stamps new users with it. 0 = single-tenant behaviour.
+	providerID int64
+}
+
+// SetProviderID pins this driver instance to a tenant. Called by the
+// multi-provider dispatcher right after Init.
+func (d *Driver) SetProviderID(id int64) {
+	d.mu.Lock()
+	d.providerID = id
+	d.mu.Unlock()
 }
 
 // New constructs an empty OIDC driver — Init must be called.
@@ -146,6 +158,7 @@ func (d *Driver) HandleCallback(w http.ResponseWriter, r *http.Request) (*model.
 	verifier := d.verifier
 	roleClaim := d.roleClaim
 	adminGroup := d.adminGroup
+	providerID := d.providerID
 	d.mu.RUnlock()
 	if oauthCfg == nil {
 		return nil, "", errors.New("oidc: not initialized")
@@ -196,13 +209,40 @@ func (d *Driver) HandleCallback(w http.ResponseWriter, r *http.Request) (*model.
 		}
 	}
 
-	// Upsert user.
+	// Upsert user. In multi-tenant mode (providerID set) the lookup is scoped to
+	// THIS tenant, a new user is JIT-stamped with it, and the tag is immutable —
+	// an email already registered to another tenant cannot hop realms (the JIT
+	// create then fails on the unique email and the login is refused).
 	ctx := r.Context()
-	user, err := d.store.GetUserByEmail(ctx, strings.ToLower(email))
-	if err != nil {
-		user, err = d.store.CreateUser(ctx, strings.ToLower(email), "", role, "en", "UTC")
+	lower := strings.ToLower(email)
+	var user *model.User
+	if providerID != 0 {
+		user, err = d.store.GetUserByProviderEmail(ctx, providerID, lower)
 		if err != nil {
-			return nil, "", fmt.Errorf("oidc: upsert user: %w", err)
+			return nil, "", fmt.Errorf("oidc: lookup user: %w", err)
+		}
+		if user == nil {
+			user, err = d.store.CreateUser(ctx, lower, "", role, "en", "UTC")
+			if err != nil {
+				return nil, "", fmt.Errorf("oidc: this email is registered to another tenant: %w", err)
+			}
+			if err := d.store.SetUserProvider(ctx, user.ID, providerID, idTok.Subject); err != nil {
+				return nil, "", fmt.Errorf("oidc: stamp tenant: %w", err)
+			}
+			if u2, err := d.store.GetUser(ctx, user.ID); err == nil {
+				user = u2
+			}
+		} else if user.OIDCSubject == "" {
+			// Backfill the subject for a pre-existing tenant user.
+			_ = d.store.SetUserProvider(ctx, user.ID, providerID, idTok.Subject)
+		}
+	} else {
+		user, err = d.store.GetUserByEmail(ctx, lower)
+		if err != nil {
+			user, err = d.store.CreateUser(ctx, lower, "", role, "en", "UTC")
+			if err != nil {
+				return nil, "", fmt.Errorf("oidc: upsert user: %w", err)
+			}
 		}
 	}
 	_ = d.store.TouchLastLogin(ctx, user.ID)

--- a/backend/internal/auth/login_policy.go
+++ b/backend/internal/auth/login_policy.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
+)
+
+// LoginAllowed reports whether an authenticated user may start a session.
+//
+// Two tenant-level gates (docs/MULTI-TENANCY.md):
+//   - SUSPEND: a disabled provider's users cannot log in (data intact) — in
+//     both modes. The supertenant cannot be suspended out of its own platform.
+//   - MAINTENANCE MODE: multi-tenant OFF on an install that has grown tenants
+//     ⇒ only the supertenant provider's users may log in; tenants are locked
+//     out until the flag returns (reversible, nothing touched). A plain
+//     single-tenant install is unaffected — its only provider IS the
+//     supertenant.
+//
+// It fails toward availability: a NULL provider (bootstrap/legacy admin) or an
+// unresolvable provider is allowed, so an operator is never locked out by a
+// glitch. Only a resolvable, non-supertenant tenant is ever refused.
+func LoginAllowed(ctx context.Context, store db.Store, multiTenant bool, u *model.User) bool {
+	if u == nil || u.ProviderID == nil {
+		return true
+	}
+	p, err := store.GetProvider(ctx, *u.ProviderID)
+	if err != nil || p == nil {
+		return true
+	}
+	if p.IsSupertenant {
+		return true
+	}
+	if !p.Enabled {
+		return false // suspended tenant
+	}
+	return multiTenant // mode off + tenants exist ⇒ maintenance lockout
+}

--- a/backend/internal/auth/tenant_middleware.go
+++ b/backend/internal/auth/tenant_middleware.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/tenant"
+)
+
+// TenantResolver derives the request's tenant (provider) scope from the
+// authenticated user's provider_id and stashes it in the context for the scoped
+// store and storage confinement to read. It is a **no-op when multi-tenant mode
+// is off** — no scope is set, and callers treat the absence as "unscoped", so
+// single-tenant behaviour is byte-unchanged. Mount it AFTER the auth middleware
+// so the user is already resolved.
+//
+// The user's own provider_id — not the request Host — is the source of truth
+// for scoping: a user belongs to exactly one tenant regardless of which host
+// they reach. (Host binding drives which OIDC realm authenticates a *login*;
+// that is the login layer's concern, not request scoping.)
+//
+// A supertenant scope carries IsSupertenant + no StorageIDs; it is
+// confine-exempt and cross-tenant (see docs/MULTI-TENANCY.md).
+func TenantResolver(store db.Store, multiTenant bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if !multiTenant {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			u := UserFrom(r.Context())
+			if u == nil {
+				// Unauthenticated / public path — no user, no scope. The scoped
+				// store leaves an unscoped context alone (that is how workers and
+				// pre-auth paths behave); public handlers do their own checks.
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Authenticated request in multi-tenant mode: ALWAYS attach a scope so
+			// the scoped store filters. A user whose provider is missing or
+			// unknown gets tenant.DenyAll (sees nothing) — fail closed, never a
+			// silent fall-through to "see everything".
+			scope := tenant.DenyAll
+			if u.ProviderID != nil {
+				if p, err := store.GetProvider(r.Context(), *u.ProviderID); err == nil && p != nil {
+					scope = &tenant.Scope{ProviderID: p.ID, Slug: p.Slug, IsSupertenant: p.IsSupertenant}
+					if !p.IsSupertenant {
+						scope.StorageIDs, _ = store.ListProviderStorageIDs(r.Context(), p.ID)
+					}
+				}
+			}
+			next.ServeHTTP(w, r.WithContext(tenant.WithScope(r.Context(), scope)))
+		})
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -29,6 +29,11 @@ type Config struct {
 	PublicURL        string       `yaml:"public_url"`
 	DataDir          string       `yaml:"data_dir"`
 	DefaultLocale    string       `yaml:"default_locale"`
+	// MultiTenant turns on native multi-tenancy (host-resolved provider =
+	// tenant, per-provider storage confinement, scoped user directory). OFF by
+	// default — a single-tenant install behaves exactly as before. See
+	// docs/MULTI-TENANCY.md.
+	MultiTenant      bool         `yaml:"multi_tenant"`
 	Log              LogConfig    `yaml:"log"`
 	DB               DBConfig     `yaml:"db"`
 	Auth             AuthConfig   `yaml:"auth"`
@@ -98,7 +103,7 @@ type SeedStorage struct {
 }
 
 // SentryConfig — optional Sentry-wire error reporting (self-hosted GlitchTip at
-// errors.example.com). An empty DSN disables it entirely (default build reports
+// errors.brf.sh). An empty DSN disables it entirely (default build reports
 // nothing). Environment tags events (e.g. production / demo) so one project can
 // serve multiple deployments.
 type SentryConfig struct {
@@ -375,6 +380,9 @@ func applyEnv(c *Config) {
 	if v := os.Getenv("FILEX_DEFAULT_LOCALE"); v != "" {
 		c.DefaultLocale = v
 	}
+	if v := os.Getenv("FILEX_MULTI_TENANT"); v == "1" || v == "true" {
+		c.MultiTenant = true
+	}
 	if v := os.Getenv("FILEX_LOG_LEVEL"); v != "" {
 		c.Log.Level = v
 	}
@@ -397,7 +405,7 @@ func applyEnv(c *Config) {
 	//   FILEX_OIDC_*       (deploy/.env.example + docs)
 	//   FILEX_AUTH_OIDC_*  (legacy from earlier draft of this file)
 	// The shorter form wins when both are set, matching the convention
-	// used in deploy/demo-fm.example.com.compose.yml + plan files.
+	// used in deploy/demo-fm.brf.sh.compose.yml + plan files.
 	if v := os.Getenv("FILEX_AUTH_DRIVERS"); v != "" {
 		parts := strings.Split(v, ",")
 		out := make([]string, 0, len(parts))

--- a/backend/internal/db/drivers/postgres/postgres.go
+++ b/backend/internal/db/drivers/postgres/postgres.go
@@ -333,6 +333,148 @@ func (s *Store) SetNodeMtime(ctx context.Context, id int64, mtime *time.Time) er
 	return err
 }
 
+// ─── Providers (tenants) — see docs/MULTI-TENANCY.md ─────────────────
+
+const providerCols = `id, slug, name, COALESCE(host,''), auth_type, ` +
+	`COALESCE(oidc_issuer,''), COALESCE(oidc_client_id,''), COALESCE(oidc_client_secret,''), ` +
+	`COALESCE(oidc_redirect_url,''), COALESCE(role_claim,''), COALESCE(admin_group,''), ` +
+	`is_supertenant, enabled, created_at, updated_at`
+
+func scanProvider(r rowScanner) (*model.Provider, error) {
+	p := &model.Provider{}
+	if err := r.Scan(&p.ID, &p.Slug, &p.Name, &p.Host, &p.AuthType,
+		&p.OIDCIssuer, &p.OIDCClientID, &p.OIDCClientSecret, &p.OIDCRedirectURL,
+		&p.RoleClaim, &p.AdminGroup, &p.IsSupertenant, &p.Enabled,
+		&p.CreatedAt, &p.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (s *Store) CreateProvider(ctx context.Context, p *model.Provider) (*model.Provider, error) {
+	at := p.AuthType
+	if at == "" {
+		at = model.AuthTypeOIDC
+	}
+	row := s.db.QueryRowContext(ctx,
+		`INSERT INTO providers (slug, name, host, auth_type, oidc_issuer, oidc_client_id, oidc_client_secret, oidc_redirect_url, role_claim, admin_group, is_supertenant, enabled)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING `+providerCols,
+		p.Slug, p.Name, p.Host, at, p.OIDCIssuer, p.OIDCClientID, p.OIDCClientSecret,
+		p.OIDCRedirectURL, p.RoleClaim, p.AdminGroup, p.IsSupertenant, p.Enabled)
+	return scanProvider(row)
+}
+
+func (s *Store) GetProvider(ctx context.Context, id int64) (*model.Provider, error) {
+	return scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE id=$1`, id))
+}
+
+func (s *Store) GetProviderBySlug(ctx context.Context, slug string) (*model.Provider, error) {
+	p, err := scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE slug=$1`, slug))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+func (s *Store) GetProviderByHost(ctx context.Context, host string) (*model.Provider, error) {
+	p, err := scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE host=$1 AND enabled=TRUE`, host))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+func (s *Store) GetSupertenant(ctx context.Context) (*model.Provider, error) {
+	p, err := scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE is_supertenant=TRUE ORDER BY id LIMIT 1`))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+func (s *Store) ListProviders(ctx context.Context) ([]*model.Provider, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+providerCols+` FROM providers ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*model.Provider
+	for rows.Next() {
+		p, err := scanProvider(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) UpdateProvider(ctx context.Context, p *model.Provider) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE providers SET slug=$1, name=$2, host=$3, auth_type=$4, oidc_issuer=$5, oidc_client_id=$6, oidc_client_secret=$7, oidc_redirect_url=$8, role_claim=$9, admin_group=$10, is_supertenant=$11, enabled=$12, updated_at=NOW() WHERE id=$13`,
+		p.Slug, p.Name, p.Host, p.AuthType, p.OIDCIssuer, p.OIDCClientID, p.OIDCClientSecret,
+		p.OIDCRedirectURL, p.RoleClaim, p.AdminGroup, p.IsSupertenant, p.Enabled, p.ID)
+	return err
+}
+
+func (s *Store) DeleteProvider(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM providers WHERE id=$1`, id)
+	return err
+}
+
+func (s *Store) LinkProviderStorage(ctx context.Context, providerID, storageID int64) error {
+	var n int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM provider_storages WHERE provider_id=$1 AND storage_id=$2`,
+		providerID, storageID).Scan(&n); err != nil {
+		return err
+	}
+	if n > 0 {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO provider_storages (provider_id, storage_id) VALUES ($1,$2)`, providerID, storageID)
+	return err
+}
+
+func (s *Store) UnlinkProviderStorage(ctx context.Context, providerID, storageID int64) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM provider_storages WHERE provider_id=$1 AND storage_id=$2`, providerID, storageID)
+	return err
+}
+
+func (s *Store) ListProviderStorageIDs(ctx context.Context, providerID int64) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT storage_id FROM provider_storages WHERE provider_id=$1 ORDER BY storage_id`, providerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetProviderIDForStorage(ctx context.Context, storageID int64) (int64, bool, error) {
+	var pid int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT provider_id FROM provider_storages WHERE storage_id=$1 ORDER BY provider_id LIMIT 1`,
+		storageID).Scan(&pid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return pid, true, nil
+}
+
 func (s *Store) UpdateNodeMeta(ctx context.Context, id int64, size int64, mime, etag string, mtime time.Time) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE nodes SET size=$1, mime=$2, etag=$3, backend_mtime=$4, seen_at=NOW(), updated_at=NOW() WHERE id=$5`, size, mime, etag, mtime, id)
 	return err
@@ -441,14 +583,50 @@ func (s *Store) SearchNodes(ctx context.Context, storageID int64, like string, l
 // the login second-factor check on Postgres.
 const userCols = `id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, ` +
 	`COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,FALSE), ` +
-	`COALESCE(totp_recovery_codes_json::text,'[]'), locale, timezone, created_at, updated_at, last_login_at`
+	`COALESCE(totp_recovery_codes_json::text,'[]'), locale, timezone, created_at, updated_at, last_login_at, ` +
+	`provider_id, COALESCE(oidc_subject,'')`
 
 func (s *Store) CreateUser(ctx context.Context, email, hash, role, locale, tz string) (*model.User, error) {
+	// New users default to the always-present "default" provider (the
+	// supertenant); OIDC JIT overrides via SetUserProvider. See sqlite driver.
 	row := s.db.QueryRowContext(ctx,
-		`INSERT INTO users (email, password_hash, role, locale, timezone) VALUES ($1,$2,$3,$4,$5)
+		`INSERT INTO users (email, password_hash, role, locale, timezone, provider_id)
+		 VALUES ($1,$2,$3,$4,$5, (SELECT id FROM providers WHERE slug='default'))
 		 RETURNING `+userCols,
 		email, hash, role, locale, tz)
 	return scanUser(row)
+}
+
+func (s *Store) SetUserProvider(ctx context.Context, userID, providerID int64, oidcSubject string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE users SET provider_id=$1, oidc_subject=$2, updated_at=NOW() WHERE id=$3`,
+		providerID, oidcSubject, userID)
+	return err
+}
+
+func (s *Store) GetUserByProviderEmail(ctx context.Context, providerID int64, email string) (*model.User, error) {
+	u, err := scanUser(s.db.QueryRowContext(ctx, `SELECT `+userCols+` FROM users WHERE provider_id=$1 AND email=$2`, providerID, email))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return u, err
+}
+
+func (s *Store) ListUsersByProvider(ctx context.Context, providerID int64) ([]*model.User, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+userCols+` FROM users WHERE provider_id=$1 ORDER BY id`, providerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*model.User
+	for rows.Next() {
+		u, err := scanUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) GetUser(ctx context.Context, id int64) (*model.User, error) {
@@ -1086,11 +1264,16 @@ func scanStorage(r rowScanner) (*model.Storage, error) {
 func scanUser(r rowScanner) (*model.User, error) {
 	u := &model.User{}
 	var recoveryJSON string
-	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &u.TOTPEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt); err != nil {
+	var providerID sql.NullInt64
+	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &u.TOTPEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject); err != nil {
 		return nil, err
 	}
 	if recoveryJSON != "" {
 		_ = json.Unmarshal([]byte(recoveryJSON), &u.TOTPRecoveryCodes)
+	}
+	if providerID.Valid {
+		v := providerID.Int64
+		u.ProviderID = &v
 	}
 	return u, nil
 }

--- a/backend/internal/db/drivers/sqlite/sqlite.go
+++ b/backend/internal/db/drivers/sqlite/sqlite.go
@@ -345,6 +345,154 @@ func (s *Store) SetNodeMtime(ctx context.Context, id int64, mtime *time.Time) er
 	return err
 }
 
+// ─── Providers (tenants) — see docs/MULTI-TENANCY.md ─────────────────
+// SQL here is kept portable (no ON CONFLICT / INSERT OR IGNORE) because the
+// MySQL driver reuses this Store verbatim.
+
+const providerCols = `id, slug, name, COALESCE(host,''), auth_type, ` +
+	`COALESCE(oidc_issuer,''), COALESCE(oidc_client_id,''), COALESCE(oidc_client_secret,''), ` +
+	`COALESCE(oidc_redirect_url,''), COALESCE(role_claim,''), COALESCE(admin_group,''), ` +
+	`is_supertenant, enabled, created_at, updated_at`
+
+func scanProvider(r rowScanner) (*model.Provider, error) {
+	p := &model.Provider{}
+	if err := r.Scan(&p.ID, &p.Slug, &p.Name, &p.Host, &p.AuthType,
+		&p.OIDCIssuer, &p.OIDCClientID, &p.OIDCClientSecret, &p.OIDCRedirectURL,
+		&p.RoleClaim, &p.AdminGroup, &p.IsSupertenant, &p.Enabled,
+		&p.CreatedAt, &p.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (s *Store) CreateProvider(ctx context.Context, p *model.Provider) (*model.Provider, error) {
+	at := p.AuthType
+	if at == "" {
+		at = model.AuthTypeOIDC
+	}
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO providers (slug, name, host, auth_type, oidc_issuer, oidc_client_id, oidc_client_secret, oidc_redirect_url, role_claim, admin_group, is_supertenant, enabled)
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+		p.Slug, p.Name, p.Host, at, p.OIDCIssuer, p.OIDCClientID, p.OIDCClientSecret,
+		p.OIDCRedirectURL, p.RoleClaim, p.AdminGroup, btoi(p.IsSupertenant), btoi(p.Enabled))
+	if err != nil {
+		return nil, err
+	}
+	id, _ := res.LastInsertId()
+	return s.GetProvider(ctx, id)
+}
+
+func (s *Store) GetProvider(ctx context.Context, id int64) (*model.Provider, error) {
+	return scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE id=?`, id))
+}
+
+func (s *Store) GetProviderBySlug(ctx context.Context, slug string) (*model.Provider, error) {
+	p, err := scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE slug=?`, slug))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+func (s *Store) GetProviderByHost(ctx context.Context, host string) (*model.Provider, error) {
+	p, err := scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE host=? AND enabled=1`, host))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+func (s *Store) GetSupertenant(ctx context.Context) (*model.Provider, error) {
+	p, err := scanProvider(s.db.QueryRowContext(ctx, `SELECT `+providerCols+` FROM providers WHERE is_supertenant=1 ORDER BY id LIMIT 1`))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return p, err
+}
+
+func (s *Store) ListProviders(ctx context.Context) ([]*model.Provider, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+providerCols+` FROM providers ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*model.Provider
+	for rows.Next() {
+		p, err := scanProvider(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) UpdateProvider(ctx context.Context, p *model.Provider) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE providers SET slug=?, name=?, host=?, auth_type=?, oidc_issuer=?, oidc_client_id=?, oidc_client_secret=?, oidc_redirect_url=?, role_claim=?, admin_group=?, is_supertenant=?, enabled=?, updated_at=CURRENT_TIMESTAMP WHERE id=?`,
+		p.Slug, p.Name, p.Host, p.AuthType, p.OIDCIssuer, p.OIDCClientID, p.OIDCClientSecret,
+		p.OIDCRedirectURL, p.RoleClaim, p.AdminGroup, btoi(p.IsSupertenant), btoi(p.Enabled), p.ID)
+	return err
+}
+
+func (s *Store) DeleteProvider(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM providers WHERE id=?`, id)
+	return err
+}
+
+func (s *Store) LinkProviderStorage(ctx context.Context, providerID, storageID int64) error {
+	var n int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM provider_storages WHERE provider_id=? AND storage_id=?`,
+		providerID, storageID).Scan(&n); err != nil {
+		return err
+	}
+	if n > 0 {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO provider_storages (provider_id, storage_id) VALUES (?,?)`, providerID, storageID)
+	return err
+}
+
+func (s *Store) UnlinkProviderStorage(ctx context.Context, providerID, storageID int64) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM provider_storages WHERE provider_id=? AND storage_id=?`, providerID, storageID)
+	return err
+}
+
+func (s *Store) ListProviderStorageIDs(ctx context.Context, providerID int64) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT storage_id FROM provider_storages WHERE provider_id=? ORDER BY storage_id`, providerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetProviderIDForStorage(ctx context.Context, storageID int64) (int64, bool, error) {
+	var pid int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT provider_id FROM provider_storages WHERE storage_id=? ORDER BY provider_id LIMIT 1`,
+		storageID).Scan(&pid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return pid, true, nil
+}
+
 func (s *Store) UpdateNodeMeta(ctx context.Context, id int64, size int64, mime, etag string, mtime time.Time) error {
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE nodes SET size=?, mime=?, etag=?, backend_mtime=?, seen_at=CURRENT_TIMESTAMP, updated_at=CURRENT_TIMESTAMP WHERE id=?`,
@@ -461,14 +609,59 @@ func (s *Store) SearchNodes(ctx context.Context, storageID int64, like string, l
 // ─────────────────── Users ───────────────────
 
 func (s *Store) CreateUser(ctx context.Context, email, passwordHash, role, locale, tz string) (*model.User, error) {
+	// Every user belongs to a provider (tenant). New users default to the
+	// always-present "default" provider (the supertenant), so single-tenant
+	// installs behave unchanged and every user can log in; OIDC JIT overrides
+	// this with the host-resolved tenant via SetUserProvider. This keeps the
+	// CreateUser signature stable for its many callers.
 	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO users (email, password_hash, role, locale, timezone) VALUES (?,?,?,?,?)`,
+		`INSERT INTO users (email, password_hash, role, locale, timezone, provider_id)
+		 VALUES (?,?,?,?,?, (SELECT id FROM providers WHERE slug='default'))`,
 		email, passwordHash, role, locale, tz)
 	if err != nil {
 		return nil, err
 	}
 	id, _ := res.LastInsertId()
 	return s.GetUser(ctx, id)
+}
+
+// SetUserProvider re-homes a user to a provider (tenant) and records its OIDC
+// subject. Used by OIDC JIT to stamp the host-resolved tenant. Passing an empty
+// oidcSubject leaves the column as-is is NOT done here — it is overwritten, so
+// callers should pass the current value when only changing the provider.
+func (s *Store) SetUserProvider(ctx context.Context, userID, providerID int64, oidcSubject string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE users SET provider_id=?, oidc_subject=?, updated_at=CURRENT_TIMESTAMP WHERE id=?`,
+		providerID, oidcSubject, userID)
+	return err
+}
+
+// GetUserByProviderEmail looks a user up within a single provider (tenant), the
+// multi-tenant analogue of GetUserByEmail. Returns (nil, nil) if absent.
+func (s *Store) GetUserByProviderEmail(ctx context.Context, providerID int64, email string) (*model.User, error) {
+	u, err := scanUser(s.db.QueryRowContext(ctx, userSelect()+` FROM users WHERE provider_id=? AND email=?`, providerID, email))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return u, err
+}
+
+// ListUsersByProvider lists a tenant's users (provider admin + delete-cascade).
+func (s *Store) ListUsersByProvider(ctx context.Context, providerID int64) ([]*model.User, error) {
+	rows, err := s.db.QueryContext(ctx, userSelect()+` FROM users WHERE provider_id=? ORDER BY id`, providerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*model.User
+	for rows.Next() {
+		u, err := scanUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) GetUser(ctx context.Context, id int64) (*model.User, error) {
@@ -1356,19 +1549,24 @@ func scanStorage(r rowScanner) (*model.Storage, error) {
 }
 
 func userSelect() string {
-	return `SELECT id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_recovery_codes_json,'[]'), locale, timezone, created_at, updated_at, last_login_at`
+	return `SELECT id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_recovery_codes_json,'[]'), locale, timezone, created_at, updated_at, last_login_at, provider_id, COALESCE(oidc_subject,'')`
 }
 
 func scanUser(r rowScanner) (*model.User, error) {
 	u := &model.User{}
 	var totpEnabled int
 	var recoveryJSON string
-	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &totpEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt); err != nil {
+	var providerID sql.NullInt64
+	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &totpEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject); err != nil {
 		return nil, err
 	}
 	u.TOTPEnabled = totpEnabled == 1
 	if recoveryJSON != "" {
 		_ = json.Unmarshal([]byte(recoveryJSON), &u.TOTPRecoveryCodes)
+	}
+	if providerID.Valid {
+		v := providerID.Int64
+		u.ProviderID = &v
 	}
 	return u, nil
 }

--- a/backend/internal/db/provider_test.go
+++ b/backend/internal/db/provider_test.go
@@ -1,0 +1,96 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// TestProviderStore exercises the tenant/provider store on a real (sqlite)
+// migrated DB: the migration-seeded default supertenant, CRUD, host resolution,
+// storage links (idempotent) and the reverse lookup workers use.
+func TestProviderStore(t *testing.T) {
+	_, store := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	// Migration 00014 seeds a "default" provider that is the supertenant.
+	def, err := store.GetProviderBySlug(ctx, model.DefaultProviderSlug)
+	require.NoError(t, err)
+	require.NotNil(t, def)
+	assert.True(t, def.IsSupertenant, "default provider is the supertenant")
+
+	st, err := store.GetSupertenant(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, def.ID, st.ID)
+
+	// Create a host-bound tenant.
+	p, err := store.CreateProvider(ctx, &model.Provider{
+		Slug: "acme", Name: "Acme", Host: "files.acme.test",
+		AuthType: model.AuthTypeOIDC, OIDCIssuer: "https://kc/realms/acme",
+		AdminGroup: "admins", Enabled: true,
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, p.ID)
+	assert.False(t, p.IsSupertenant)
+	assert.Equal(t, "files.acme.test", p.Host)
+
+	// Resolve by host; unknown host → (nil, nil).
+	byHost, err := store.GetProviderByHost(ctx, "files.acme.test")
+	require.NoError(t, err)
+	require.NotNil(t, byHost)
+	assert.Equal(t, p.ID, byHost.ID)
+
+	none, err := store.GetProviderByHost(ctx, "nobody.test")
+	require.NoError(t, err)
+	assert.Nil(t, none)
+
+	// A disabled provider does not resolve by host.
+	p.Enabled = false
+	require.NoError(t, store.UpdateProvider(ctx, p))
+	off, err := store.GetProviderByHost(ctx, "files.acme.test")
+	require.NoError(t, err)
+	assert.Nil(t, off)
+	p.Enabled = true
+	require.NoError(t, store.UpdateProvider(ctx, p))
+
+	// Link a storage; linking is idempotent.
+	stor, err := store.CreateStorage(ctx, &model.Storage{
+		Name: "acme-store", Driver: "local", MountPath: "/",
+		ConfigJSON: []byte(`{"path":"/tmp/acme"}`),
+		SyncMode:   model.SyncModePoll, SyncIntervalS: 900, Enabled: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.LinkProviderStorage(ctx, p.ID, stor.ID))
+	require.NoError(t, store.LinkProviderStorage(ctx, p.ID, stor.ID))
+	ids, err := store.ListProviderStorageIDs(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{stor.ID}, ids)
+
+	// Reverse lookup — a worker deriving tenancy from a storage.
+	pid, ok, err := store.GetProviderIDForStorage(ctx, stor.ID)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, p.ID, pid)
+
+	unlinked, ok, err := store.GetProviderIDForStorage(ctx, 999999)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Zero(t, unlinked)
+
+	// Unlink.
+	require.NoError(t, store.UnlinkProviderStorage(ctx, p.ID, stor.ID))
+	ids, err = store.ListProviderStorageIDs(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+
+	// List includes default + acme.
+	all, err := store.ListProviders(ctx)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(all), 2)
+}

--- a/backend/internal/db/store.go
+++ b/backend/internal/db/store.go
@@ -94,6 +94,11 @@ type Store interface {
 	CreateUser(ctx context.Context, email, passwordHash, role, locale, tz string) (*model.User, error)
 	GetUser(ctx context.Context, id int64) (*model.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*model.User, error)
+	// Multi-tenancy (docs/MULTI-TENANCY.md): look a user up within one provider
+	// (tenant); re-home a user to a provider + record its OIDC subject (JIT).
+	GetUserByProviderEmail(ctx context.Context, providerID int64, email string) (*model.User, error)
+	SetUserProvider(ctx context.Context, userID, providerID int64, oidcSubject string) error
+	ListUsersByProvider(ctx context.Context, providerID int64) ([]*model.User, error)
 	ListUsers(ctx context.Context) ([]*model.User, error)
 	CountUsers(ctx context.Context) (int64, error)
 	UpdateUserPassword(ctx context.Context, id int64, hash string) error
@@ -279,6 +284,28 @@ type Store interface {
 
 	GetReplicaSettings(ctx context.Context) (*model.ReplicaSettings, error)
 	UpsertReplicaSettings(ctx context.Context, s *model.ReplicaSettings) error
+
+	// Providers (tenants). See docs/MULTI-TENANCY.md. Inert while multi-tenant
+	// mode is off; a single "default" provider always exists (migration 00014).
+	CreateProvider(ctx context.Context, p *model.Provider) (*model.Provider, error)
+	GetProvider(ctx context.Context, id int64) (*model.Provider, error)
+	GetProviderBySlug(ctx context.Context, slug string) (*model.Provider, error)
+	// GetProviderByHost resolves a request Host to its tenant; returns nil if no
+	// enabled provider claims that host.
+	GetProviderByHost(ctx context.Context, host string) (*model.Provider, error)
+	ListProviders(ctx context.Context) ([]*model.Provider, error)
+	UpdateProvider(ctx context.Context, p *model.Provider) error
+	DeleteProvider(ctx context.Context, id int64) error
+	// GetSupertenant returns the single is_supertenant provider, or nil.
+	GetSupertenant(ctx context.Context) (*model.Provider, error)
+
+	// Provider ↔ storage links (M:N; 1:1 in the first UI).
+	LinkProviderStorage(ctx context.Context, providerID, storageID int64) error
+	UnlinkProviderStorage(ctx context.Context, providerID, storageID int64) error
+	ListProviderStorageIDs(ctx context.Context, providerID int64) ([]int64, error)
+	// GetProviderIDForStorage returns the (first) provider a storage is linked
+	// to — used by background workers to derive tenancy from a storage.
+	GetProviderIDForStorage(ctx context.Context, storageID int64) (int64, bool, error)
 }
 
 // ExternalService is the DB row representation. Lives in the db package so

--- a/backend/internal/db/user_provider_test.go
+++ b/backend/internal/db/user_provider_test.go
@@ -1,0 +1,66 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/auth"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// TestUserProviderAndMaintenanceMode covers the phase-4 auth core: new users join
+// the default (supertenant) provider, JIT re-homes them to a tenant, lookups are
+// provider-scoped, and maintenance mode (multi-tenant off + tenants present)
+// locks out tenant users while the supertenant keeps signing in.
+func TestUserProviderAndMaintenanceMode(t *testing.T) {
+	_, store := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	// A new user defaults to the always-present default provider (supertenant).
+	u, err := store.CreateUser(ctx, "a@x.test", "", model.RoleUser, "en", "UTC")
+	require.NoError(t, err)
+	require.NotNil(t, u.ProviderID, "new user is stamped with a provider")
+	def, err := store.GetProviderBySlug(ctx, model.DefaultProviderSlug)
+	require.NoError(t, err)
+	assert.Equal(t, def.ID, *u.ProviderID, "new user joins the default provider")
+
+	// Maintenance mode allows a default/supertenant user (single-tenant unchanged).
+	assert.True(t, auth.LoginAllowed(ctx, store, false, u))
+	assert.True(t, auth.LoginAllowed(ctx, store, true, u)) // mode on: allowed too
+
+	// Create a tenant provider and re-home the user to it (JIT stamp).
+	p, err := store.CreateProvider(ctx, &model.Provider{Slug: "acme", Name: "Acme", Host: "a.test", Enabled: true})
+	require.NoError(t, err)
+	require.NoError(t, store.SetUserProvider(ctx, u.ID, p.ID, "oidc-sub-123"))
+
+	// Provider-scoped lookup finds it under acme, not under default.
+	got, err := store.GetUserByProviderEmail(ctx, p.ID, "a@x.test")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "oidc-sub-123", got.OIDCSubject)
+	require.NotNil(t, got.ProviderID)
+	assert.Equal(t, p.ID, *got.ProviderID)
+
+	miss, err := store.GetUserByProviderEmail(ctx, def.ID, "a@x.test")
+	require.NoError(t, err)
+	assert.Nil(t, miss, "user is no longer in the default provider")
+
+	// Maintenance mode (off + tenant present) LOCKS OUT the tenant user...
+	assert.False(t, auth.LoginAllowed(ctx, store, false, got))
+	// ...but mode-on allows it, and a nil-provider bootstrap admin is always ok.
+	assert.True(t, auth.LoginAllowed(ctx, store, true, got))
+	assert.True(t, auth.LoginAllowed(ctx, store, false, &model.User{}))
+
+	// SUSPEND: a disabled tenant's users cannot log in — in either mode.
+	p.Enabled = false
+	require.NoError(t, store.UpdateProvider(ctx, p))
+	assert.False(t, auth.LoginAllowed(ctx, store, true, got))
+	assert.False(t, auth.LoginAllowed(ctx, store, false, got))
+	p.Enabled = true
+	require.NoError(t, store.UpdateProvider(ctx, p))
+	assert.True(t, auth.LoginAllowed(ctx, store, true, got))
+}

--- a/backend/internal/model/provider.go
+++ b/backend/internal/model/provider.go
@@ -1,0 +1,57 @@
+package model
+
+import "time"
+
+// Auth types a provider (tenant) can use to authenticate its users.
+const (
+	AuthTypeOIDC  = "oidc"
+	AuthTypeLocal = "local"
+)
+
+// DefaultProviderSlug is the always-present "original org" tenant. It is created
+// by migration 00014 and is inert while multi-tenant mode is off. On a
+// multi-tenant install it doubles as the platform supertenant by default (see
+// docs/MULTI-TENANCY.md); operators may add further providers as tenants.
+const DefaultProviderSlug = "default"
+
+// Provider is a tenant: an auth realm (OIDC or local) bound to a host and
+// linked to one or more storages via provider_storages. Users carry a
+// provider_id tag assigned at (JIT) login.
+//
+// Isolation is enforced in TWO independent layers (docs/MULTI-TENANCY.md):
+//  1. file data — storage confinement (a provider only reaches its linked
+//     storages); a bug here is the only way file data could cross a tenant.
+//  2. directory — user/share/grant scoping by provider_id; a bug here leaks at
+//     most a name, never file data.
+//
+// A provider with IsSupertenant is confine-EXEMPT and platform-scoped: its
+// admins see every tenant. There must be at most one, it should be a hardened
+// realm, and a local bootstrap admin remains the break-glass path.
+type Provider struct {
+	ID       int64  `json:"id"`
+	Slug     string `json:"slug"`
+	Name     string `json:"name"`
+	Host     string `json:"host,omitempty"`
+	AuthType string `json:"auth_type"`
+
+	OIDCIssuer       string `json:"oidc_issuer,omitempty"`
+	OIDCClientID     string `json:"oidc_client_id,omitempty"`
+	OIDCClientSecret string `json:"-"` // never serialized to the client
+	OIDCRedirectURL  string `json:"oidc_redirect_url,omitempty"`
+	RoleClaim        string `json:"role_claim,omitempty"`
+	AdminGroup       string `json:"admin_group,omitempty"`
+
+	IsSupertenant bool `json:"is_supertenant"`
+	Enabled       bool `json:"enabled"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ProviderStorage links a tenant to a storage (M:N; 1:1 in the current UI).
+// A storage reachable through no provider link is only visible to a
+// supertenant / to single-tenant mode.
+type ProviderStorage struct {
+	ProviderID int64 `json:"provider_id"`
+	StorageID  int64 `json:"storage_id"`
+}

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -45,6 +45,11 @@ type User struct {
 	CreatedAt         time.Time  `json:"created_at"`
 	UpdatedAt         time.Time  `json:"updated_at"`
 	LastLoginAt       *time.Time `json:"last_login_at,omitempty"`
+	// Multi-tenancy (docs/MULTI-TENANCY.md): the tenant (provider) this user
+	// belongs to. Nil only on rows predating the 00014 backfill; assigned
+	// immutably at JIT login. OIDCSubject pins the OIDC identity per provider.
+	ProviderID  *int64 `json:"provider_id,omitempty"`
+	OIDCSubject string `json:"-"`
 }
 
 // IsAdmin returns true if the user has the admin role.
@@ -89,7 +94,7 @@ type Session struct {
 }
 
 // APIToken is a long-lived bearer credential for non-interactive callers
-// (AI agents, the work.example.com FilexClient, the MCP server). It is bound to
+// (AI agents, the work.brf.sh FilexClient, the MCP server). It is bound to
 // a user so every authenticated call inherits that user's role. The
 // plaintext value is shown only once at creation; only TokenHash (sha256
 // hex) is persisted.

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	authapitoken "github.com/brf-tech/filex/backend/internal/auth/drivers/apitoken"
 	authldap "github.com/brf-tech/filex/backend/internal/auth/drivers/ldap"
 	authlocal "github.com/brf-tech/filex/backend/internal/auth/drivers/local"
+	"github.com/brf-tech/filex/backend/internal/auth/drivers/multioidc"
 	authoidc "github.com/brf-tech/filex/backend/internal/auth/drivers/oidc"
 	authproxyheader "github.com/brf-tech/filex/backend/internal/auth/drivers/proxyheader"
 	"github.com/brf-tech/filex/backend/internal/capability"
@@ -36,6 +37,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/share"
 	"github.com/brf-tech/filex/backend/internal/storage"
 	syncpkg "github.com/brf-tech/filex/backend/internal/sync"
+	"github.com/brf-tech/filex/backend/internal/tenantstore"
 	"github.com/brf-tech/filex/backend/internal/thumb"
 	"github.com/brf-tech/filex/backend/internal/trash"
 	"github.com/brf-tech/filex/backend/internal/version"
@@ -171,7 +173,7 @@ func New(ctx context.Context, cfg config.Config, embedFS embed.FS) (*Server, err
 	}
 
 	// API-token driver is always enabled (independent of cfg.Auth.Drivers)
-	// so AI agents / the work.example.com FilexClient / MCP clients can
+	// so AI agents / the work.brf.sh FilexClient / MCP clients can
 	// authenticate against /api/files and /api/ai with X-Filex-Token or a
 	// Bearer token. Tokens are minted from /api/admin/ai-tokens.
 	{
@@ -182,6 +184,14 @@ func New(ctx context.Context, cfg config.Config, embedFS embed.FS) (*Server, err
 		enabled = append(enabled, atDrv)
 	}
 	auth.SetEnabled(enabled)
+
+	// Multi-tenant mode: dispatch OIDC per tenant realm — request host →
+	// provider row → that realm's driver (JIT stamps the tenant). Hosts with no
+	// tenant OIDC config fall back to the config-file driver above, so the
+	// operator's own login keeps working. See docs/MULTI-TENANCY.md.
+	if cfg.MultiTenant {
+		oidcDrv = multioidc.New(store, oidcDrv)
+	}
 
 	// Search index.
 	var idx *search.Index
@@ -414,9 +424,15 @@ func New(ctx context.Context, cfg config.Config, embedFS embed.FS) (*Server, err
 	// Mailer for invite/share notices — verified periodically in Start().
 	srvObj.mailer = mailer.New(store)
 
+	// Handlers see the tenant-scoped store: storage listings are confined to the
+	// request's tenant (no-op unless multi-tenant mode is on — the wrapper only
+	// diverges when the context carries a tenant scope). Background services above
+	// keep the raw `store`; their contexts carry no scope, so they are unaffected.
+	scopedStore := tenantstore.New(store)
+
 	deps := &api.Deps{
 		Cfg:             cfg,
-		Store:           store,
+		Store:           scopedStore,
 		Worker:          worker,
 		Index:           idx,
 		Caps:            caps,

--- a/backend/internal/tenant/context.go
+++ b/backend/internal/tenant/context.go
@@ -1,0 +1,63 @@
+// Package tenant carries the resolved tenant (provider) scope through a request.
+//
+// A tenant is a provider (see model.Provider). In multi-tenant mode a resolver
+// middleware puts a *Scope in the request context from the Host (browser) or the
+// api_token's user (API/agents); every tenant-scoped read then filters by it.
+// In single-tenant mode no Scope is set and the absence means "unscoped — see
+// everything", so existing behaviour is unchanged.
+//
+// This package is deliberately tiny and dependency-free (only stdlib) so both
+// the HTTP layer and the scoped store can share it without import cycles.
+package tenant
+
+import "context"
+
+// Scope is the resolved tenant for a request: which provider it belongs to,
+// whether that provider is the platform supertenant (confine-exempt and
+// cross-tenant), and the storage ids it may reach.
+type Scope struct {
+	ProviderID    int64
+	Slug          string
+	IsSupertenant bool
+	// StorageIDs are the provider's linked storages. Empty for a supertenant,
+	// which is confine-exempt and reaches every storage (see CanAccessStorage).
+	StorageIDs []int64
+}
+
+// DenyAll is a non-nil scope that grants nothing. The resolver attaches it to an
+// authenticated request whose tenant cannot be resolved, so the request fails
+// closed — it sees no storages and no directory (ProviderID 0 never matches a
+// real provider) — instead of falling through to an unscoped "see everything".
+var DenyAll = &Scope{ProviderID: 0}
+
+type ctxKey struct{}
+
+// WithScope returns a context carrying s.
+func WithScope(ctx context.Context, s *Scope) context.Context {
+	return context.WithValue(ctx, ctxKey{}, s)
+}
+
+// FromContext returns the request's tenant scope, or (nil, false) when none is
+// set — single-tenant mode, or a pre-auth/public path. Callers must treat the
+// absence as "unscoped": in multi-tenant mode a tenant-scoped operation that
+// finds no scope must fail closed rather than fall back to unscoped.
+func FromContext(ctx context.Context) (*Scope, bool) {
+	s, ok := ctx.Value(ctxKey{}).(*Scope)
+	return s, ok
+}
+
+// CanAccessStorage reports whether this scope may reach storage id. A nil scope
+// (single-tenant mode / unscoped) and a supertenant can reach any storage; a
+// regular tenant only its linked storages. This is the file-layer gate — the
+// isolation circuit that, unlike directory scoping, must never leak.
+func (s *Scope) CanAccessStorage(id int64) bool {
+	if s == nil || s.IsSupertenant {
+		return true
+	}
+	for _, sid := range s.StorageIDs {
+		if sid == id {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/tenantstore/store.go
+++ b/backend/internal/tenantstore/store.go
@@ -1,0 +1,88 @@
+// Package tenantstore wraps a db.Store so storage listings are confined to the
+// request's tenant scope (see docs/MULTI-TENANCY.md).
+//
+// Only the storage-enumeration methods are overridden — the file-isolation
+// layer's "what a tenant can see". Every other method passes through unchanged.
+// Scoping is driven entirely by the context: a request carrying a tenant.Scope
+// (set by auth.TenantResolver in multi-tenant mode) is filtered; a context with
+// no scope — background workers, startup, single-tenant mode — passes through
+// untouched. So wrapping is inert unless multi-tenant mode is on.
+package tenantstore
+
+import (
+	"context"
+
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/tenant"
+)
+
+// Store is a db.Store whose storage listings honour the context tenant scope.
+type Store struct {
+	db.Store
+}
+
+// New wraps s. Safe everywhere; it only diverges from s when the context carries
+// a tenant scope (i.e. an authenticated request in multi-tenant mode).
+func New(s db.Store) *Store { return &Store{Store: s} }
+
+// ListStorages returns only the storages the request's tenant may see.
+func (s *Store) ListStorages(ctx context.Context) ([]*model.Storage, error) {
+	out, err := s.Store.ListStorages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return confine(ctx, out), nil
+}
+
+// ListEnabledStorages returns only the enabled storages the tenant may see. This
+// is the highest-leverage chokepoint — the explorer and many handlers list
+// storages through it.
+func (s *Store) ListEnabledStorages(ctx context.Context) ([]*model.Storage, error) {
+	out, err := s.Store.ListEnabledStorages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return confine(ctx, out), nil
+}
+
+// confine drops storages the scope cannot reach. No scope (worker / single
+// tenant) or a supertenant scope returns the list unchanged.
+func confine(ctx context.Context, in []*model.Storage) []*model.Storage {
+	scope, ok := tenant.FromContext(ctx)
+	if !ok || scope.IsSupertenant {
+		return in
+	}
+	out := make([]*model.Storage, 0, len(in))
+	for _, st := range in {
+		if scope.CanAccessStorage(st.ID) {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+// ListUsers returns only the users in the request's tenant — the directory
+// (layer-2) chokepoint behind every user picker: the file-permission / grant
+// screen (GET /api/files/permissions/users), the share picker and the admin
+// user list all list through it. A tenant sees only its own users; the
+// supertenant (and single-tenant mode) sees all. This is the "users of other
+// realms are invisible" guarantee. A leak here is only a name (file data is
+// confined separately), but this is exactly the surface that must not leak.
+func (s *Store) ListUsers(ctx context.Context) ([]*model.User, error) {
+	out, err := s.Store.ListUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	scope, ok := tenant.FromContext(ctx)
+	if !ok || scope.IsSupertenant {
+		return out, nil
+	}
+	filtered := make([]*model.User, 0, len(out))
+	for _, u := range out {
+		if u.ProviderID != nil && *u.ProviderID == scope.ProviderID {
+			filtered = append(filtered, u)
+		}
+	}
+	return filtered, nil
+}

--- a/backend/internal/tenantstore/store_test.go
+++ b/backend/internal/tenantstore/store_test.go
@@ -1,0 +1,103 @@
+package tenantstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/tenant"
+	"github.com/brf-tech/filex/backend/internal/tenantstore"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// TestScopedStorageListing verifies the storage-listing chokepoint honours the
+// context tenant scope: unscoped/worker + supertenant see all; a tenant sees
+// only its linked storages; DenyAll sees nothing.
+func TestScopedStorageListing(t *testing.T) {
+	_, raw := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	mk := func(name string) int64 {
+		st, err := raw.CreateStorage(ctx, &model.Storage{
+			Name: name, Driver: "local", MountPath: "/",
+			ConfigJSON: []byte(`{"path":"/tmp/` + name + `"}`),
+			SyncMode:   model.SyncModePoll, SyncIntervalS: 900, Enabled: true,
+		})
+		require.NoError(t, err)
+		return st.ID
+	}
+	a := mk("a")
+	mk("b")
+
+	s := tenantstore.New(raw)
+	names := func(ctx context.Context) []string {
+		list, err := s.ListEnabledStorages(ctx)
+		require.NoError(t, err)
+		out := make([]string, 0, len(list))
+		for _, st := range list {
+			out = append(out, st.Name)
+		}
+		return out
+	}
+
+	// No scope (worker / single-tenant mode) → sees everything.
+	assert.ElementsMatch(t, []string{"a", "b"}, names(ctx))
+
+	// Tenant scope linked only to "a" → sees only "a".
+	scoped := tenant.WithScope(ctx, &tenant.Scope{ProviderID: 1, StorageIDs: []int64{a}})
+	assert.Equal(t, []string{"a"}, names(scoped))
+
+	// Supertenant → sees everything.
+	super := tenant.WithScope(ctx, &tenant.Scope{ProviderID: 2, IsSupertenant: true})
+	assert.ElementsMatch(t, []string{"a", "b"}, names(super))
+
+	// DenyAll (unresolvable tenant) → fails closed, sees nothing.
+	deny := tenant.WithScope(ctx, tenant.DenyAll)
+	assert.Empty(t, names(deny))
+}
+
+// TestScopedUserDirectory is the guarantee Burak cares most about: users of
+// different tenants do not see each other on the permission/grant picker (which
+// lists through ListUsers).
+func TestScopedUserDirectory(t *testing.T) {
+	_, raw := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	pa, err := raw.CreateProvider(ctx, &model.Provider{Slug: "ta", Name: "TA", Enabled: true})
+	require.NoError(t, err)
+	pb, err := raw.CreateProvider(ctx, &model.Provider{Slug: "tb", Name: "TB", Enabled: true})
+	require.NoError(t, err)
+
+	ua, err := raw.CreateUser(ctx, "a@ta.test", "", model.RoleUser, "en", "UTC")
+	require.NoError(t, err)
+	require.NoError(t, raw.SetUserProvider(ctx, ua.ID, pa.ID, ""))
+	ub, err := raw.CreateUser(ctx, "b@tb.test", "", model.RoleUser, "en", "UTC")
+	require.NoError(t, err)
+	require.NoError(t, raw.SetUserProvider(ctx, ub.ID, pb.ID, ""))
+
+	s := tenantstore.New(raw)
+	emails := func(ctx context.Context) []string {
+		list, err := s.ListUsers(ctx)
+		require.NoError(t, err)
+		out := make([]string, 0, len(list))
+		for _, u := range list {
+			out = append(out, u.Email)
+		}
+		return out
+	}
+
+	// Tenant A sees only its own user, never tenant B's.
+	got := emails(tenant.WithScope(ctx, &tenant.Scope{ProviderID: pa.ID}))
+	assert.Contains(t, got, "a@ta.test")
+	assert.NotContains(t, got, "b@tb.test")
+
+	// Supertenant sees across tenants.
+	super := emails(tenant.WithScope(ctx, &tenant.Scope{ProviderID: 999, IsSupertenant: true}))
+	assert.Subset(t, super, []string{"a@ta.test", "b@tb.test"})
+
+	// DenyAll sees nobody.
+	assert.Empty(t, emails(tenant.WithScope(ctx, tenant.DenyAll)))
+}

--- a/deploy/compose/docker-compose.multi-tenant.yml
+++ b/deploy/compose/docker-compose.multi-tenant.yml
@@ -1,0 +1,75 @@
+# filex — MULTI-TENANT example: one install serving two tenants
+# (docs/MULTI-TENANCY.md). Each tenant = its own host + OIDC realm + storage.
+#
+#   files.acme.example  → tenant "acme"  → storage acme-files
+#   files.beta.example  → tenant "beta"  → storage beta-files
+#   filex.example       → the operator (supertenant realm / config-file OIDC)
+#
+# Bring-up:
+#   1. docker compose -f docker-compose.multi-tenant.yml up -d
+#   2. Sign in as the bootstrap admin on filex.example, then provision tenants
+#      over the lifecycle API (or your own tooling):
+#        POST /api/admin/storages         {"name":"acme-files","driver":"local",
+#                                          "config":{"path":"/storages/acme/files"}}
+#        POST /api/admin/providers        {"slug":"acme","host":"files.acme.example",
+#                                          "oidc_issuer":"https://kc.example/realms/acme",
+#                                          "oidc_client_id":"filex","oidc_client_secret":"…",
+#                                          "role_claim":"realm_access.roles","admin_group":"filex-admins"}
+#        POST /api/admin/providers/{id}/storages  {"storage_id": <acme storage id>}
+#   3. Point each tenant's DNS at the proxy; per-host TLS terminates there.
+#
+# The proxy MUST pass the original Host header through (Caddy's reverse_proxy
+# does by default) — filex resolves the tenant from it. Only route trusted
+# hosts to filex (docs/MULTI-TENANCY.md §13 trusted-host).
+
+services:
+  filex:
+    image: ghcr.io/brf-tech/filex:latest
+    restart: unless-stopped
+    environment:
+      FILEX_MULTI_TENANT: "1"
+      # The operator's own URL (supertenant). Tenant hosts are provider rows.
+      FILEX_PUBLIC_URL: https://filex.example
+      FILEX_DATA_DIR: /data
+      # Bootstrap local admin = break-glass + first-run provisioning
+      # (docs/MULTI-TENANCY.md §8). The config-file OIDC below stays the
+      # operator/supertenant realm; tenant realms live in the DB.
+      FILEX_AUTH_DRIVERS: local,oidc
+      FILEX_OIDC_ISSUER: https://kc.example/realms/ops
+      FILEX_OIDC_CLIENT_ID: filex
+      FILEX_OIDC_CLIENT_SECRET: change-me
+      FILEX_OIDC_ROLE_CLAIM: realm_access.roles
+      FILEX_OIDC_ADMIN_GROUP: filex-admins
+      # Tenant storages are created in step 2 over the admin API/UI (one
+      # `local` storage per mounted path below — or point each tenant at its
+      # own S3 bucket instead) and then linked to their providers.
+    volumes:
+      - filex-data:/data
+      - acme-files:/storages/acme
+      - beta-files:/storages/beta
+
+  # Per-host TLS + Host passthrough. In production replace with your own
+  # front-door (Caddy/Traefik/nginx/cert-manager Ingress) — one cert per
+  # tenant host (SNI), all routed to the same filex.
+  proxy:
+    image: caddy:2
+    restart: unless-stopped
+    ports: ["80:80", "443:443"]
+    configs:
+      - source: caddyfile
+        target: /etc/caddy/Caddyfile
+    volumes:
+      - caddy-data:/data
+
+configs:
+  caddyfile:
+    content: |
+      filex.example, files.acme.example, files.beta.example {
+        reverse_proxy filex:5212
+      }
+
+volumes:
+  filex-data:
+  acme-files:
+  beta-files:
+  caddy-data:

--- a/deploy/helm/filex/templates/ingress.yaml
+++ b/deploy/helm/filex/templates/ingress.yaml
@@ -13,11 +13,20 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tlsSecretName }}
+  {{- if or .Values.ingress.tlsSecretName .Values.ingress.extraHosts }}
   tls:
+    {{- if .Values.ingress.tlsSecretName }}
     - hosts:
         - {{ .Values.ingress.host | quote }}
       secretName: {{ .Values.ingress.tlsSecretName }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    {{- if .tlsSecretName }}
+    - hosts:
+        - {{ .host | quote }}
+      secretName: {{ .tlsSecretName }}
+    {{- end }}
+    {{- end }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}
@@ -30,4 +39,16 @@ spec:
                 name: {{ include "filex.fullname" . }}
                 port:
                   name: http
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "filex.fullname" $ }}
+                port:
+                  name: http
+    {{- end }}
 {{- end }}

--- a/deploy/helm/filex/values.yaml
+++ b/deploy/helm/filex/values.yaml
@@ -27,6 +27,15 @@ ingress:
     # Large uploads + websockets on nginx-ingress:
     # nginx.ingress.kubernetes.io/proxy-body-size: "5g"
     # nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+  # MULTI-TENANT (docs/MULTI-TENANCY.md): one Ingress rule + TLS cert per
+  # tenant host, all routed to the same filex. Set FILEX_MULTI_TENANT=1 in
+  # `env` and provision each host as a provider over /api/admin/providers.
+  # With cert-manager, an annotation above issues each host its own cert.
+  extraHosts: []
+  # - host: files.acme.example
+  #   tlsSecretName: files-acme-example-tls
+  # - host: files.beta.example
+  #   tlsSecretName: files-beta-example-tls
 
 # /data holds the SQLite DB (if used), the search index and the thumbnail cache.
 persistence:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -41,6 +41,7 @@ are **file‑only** (noted below). Individual storages are **not** configured he
 | `FILEX_PUBLIC_URL` | `http://localhost:5212` | **The external URL users open.** Baked into share links, the OIDC redirect and OnlyOffice fetch/callback — set it to your real `https://…` domain behind a proxy. |
 | `FILEX_DATA_DIR` | `~/.filex` (`/data` in Docker) | Holds the SQLite DB, search index, thumbnail cache, first‑run secret. |
 | `FILEX_DEFAULT_LOCALE` | — | Pin the initial UI language (`en` / `tr`) for users who haven't chosen one, overriding browser detection. A user's explicit language switch still wins. |
+| `FILEX_MULTI_TENANT` | `false` | Turn on native multi-tenancy — one install serves N tenants, each a host-bound auth realm (provider) confined to its own storage(s). **Off = a normal single-tenant install, behaviour unchanged.** See [MULTI-TENANCY.md](./MULTI-TENANCY.md). |
 | `FILEX_CONFIG` | — | Path to `config.yaml` (same as `--config`). |
 
 ---

--- a/docs/MULTI-TENANCY.md
+++ b/docs/MULTI-TENANCY.md
@@ -1,0 +1,292 @@
+# Multi-tenancy (native)
+
+> Status: **in progress** — Phase 1 (schema foundation) landed on `feat/multi-tenant`.
+> This document is the design + build plan. It is the source of truth for the
+> feature; keep it in sync as phases land.
+
+## 1. Goal & shape
+
+Serve **N independent tenants from one filex install**. A tenant = an **auth
+realm (OIDC or local) bound to a host, linked to one or more storages**. Someone
+who signs in through realm X sees only storage X — *even an admin*. Sharing works
+between users of the same realm; users of other realms are invisible.
+
+This is **not** built from scratch — filex already owns the hard isolation
+primitives:
+
+- `confine.Root` — server-side path jail, cannot be bypassed by the client.
+- per-storage RBAC + item grants.
+- scoped API tokens — work.brf.sh already runs a hand-rolled version of this
+  (each project confined to `s3-test://projeler/<proje>`).
+
+Native multi-tenancy makes that a first-class, host-resolved layer.
+
+### The provider = tenant collapse
+
+A **provider** row *is* the tenant. We do not add a separate `tenants` table:
+the auth realm, the host binding, the storage links and the branding all hang off
+the provider. (If a tenant ever needs two IdPs or local+OIDC, split provider from
+tenant later — YAGNI while every tenant = one Keycloak realm.)
+
+## 2. Two isolation layers (the de-risking argument)
+
+Isolation is enforced in **two independent circuits**. Keep them separate in your
+head and in the code:
+
+1. **File data → storage confinement.** A request can only reach the storages
+   its provider is linked to; every path is confined server-side (`confine.Root`,
+   node→storage derivation, client never supplies a storage id it doesn't own).
+   This is the *only* circuit that can leak file bytes.
+2. **Directory → provider_id scoping.** User lists, share-pickers, grants, audit,
+   search results are filtered by the requester's `provider_id`.
+
+**Consequence:** a bug in layer 2 leaks *at most a user's name*, never file data,
+because layer 1 is a separate circuit. That makes this "simple-layer" tenancy,
+not the scary kind — the worst realistic outcome is a name leak, small blast
+radius. Say this explicitly in user docs; it is the reason to trust the feature.
+
+## 3. Mode gating (backward-compat is non-negotiable)
+
+`FILEX_MULTI_TENANT` (config `multi_tenant`, env `FILEX_MULTI_TENANT=1|true`).
+
+- **OFF (default):** on a plain single-tenant install (only the `default`
+  provider, which is the supertenant) it behaves **exactly** as today — the
+  scoped-store wrapper is a no-op, host resolution is skipped, admins see
+  everything, `provider_id` is inert. A CI test asserts this is byte-identical to
+  the pre-feature build — the trust anchor for OSS.
+- **OFF with tenants present = maintenance mode.** If you turn the flag off on an
+  install that already grew tenant providers, **no data is touched** and it is
+  fully reversible; the flag just gates *login*: only the **supertenant**
+  provider's users may authenticate, every tenant is locked out until you flip it
+  back on. (This is why single-tenant is unchanged: there the only provider *is*
+  the supertenant, so nobody is locked out.) Turning the mode off is therefore a
+  safe operation, not a one-way door.
+- **ON:** host resolution, per-provider confinement and directory scoping engage.
+
+This lets the OSS product sell both postures: isolation-maximalists run
+one-container-per-tenant (mode off, zero shared-process risk); scale-seekers run
+one install, mode on.
+
+### Activation / migration
+
+Flipping the flag on must not require surgery:
+
+1. There must be a super-admin. If a pre-existing OIDC provider exists, mark it
+   `is_supertenant`; if the install is local-auth only, the local bootstrap
+   admin is the super-admin.
+2. All existing users get `provider_id` = the default provider.
+3. Existing storages link to the default provider.
+
+Migration 00014 already creates the `default` provider (with `is_supertenant=1`,
+the "original org = owner") and backfills `users.provider_id`, so the invariant
+"every user has a provider" holds from the first upgrade — inertly while mode is
+off. **"Existing OIDC becomes supertenant" is a migration-time default (an
+editable row), not a hard code rule.** Turning the mode back off never corrupts
+data — it drops to the maintenance mode above (supertenant-only login), so it is
+always reversible; no guard needed.
+
+## 4. Data model
+
+New in migration `00014_multi_tenant` (3 dialects, additive only):
+
+- **`providers`** — the tenant/provider registry: `slug`, `name`, `host`,
+  `auth_type` (`oidc|local`), `oidc_*` (issuer/client_id/client_secret/redirect),
+  `role_claim`, `admin_group`, `is_supertenant`, `enabled`.
+- **`provider_storages`** — M:N link (behaviour 1:1 in the first UI; join table
+  from day 1 so 1:N is a UI change, not a migration).
+- **`users.provider_id`** (nullable FK) + **`users.oidc_subject`**.
+- A `default` provider row + `users.provider_id` backfill.
+
+Placement rationale — **scope by ownership, not a column on every table.**
+Everything reachable *only through a storage* (nodes, shares, grants, sync_runs,
+thumbs, conflicts) inherits tenancy through `storage_id` → `provider_storages`;
+it needs **no** `tenant_id`. Everything reachable through a user
+(sessions, api_tokens, notifications) inherits through `user_id` → `provider_id`.
+So the tenant tag lives on just **providers, users** (+ per-tenant `settings`
+later). `api_tokens` need **no** column — a token's tenant is its user's tenant.
+
+### Still to schema (later phases, deliberately deferred here)
+
+- **users email uniqueness** → swap global `UNIQUE(email)` to
+  `UNIQUE(provider_id, email)`. Needs a sqlite table-rebuild and a mysql index
+  swap; lands with the JIT/login code that actually needs per-provider emails.
+- **`oidc_client_secret`** should be encrypted at rest, reusing the
+  `external_services.secret_enc` pattern.
+- **`settings.provider_id`** (nullable = global) for per-tenant branding.
+
+## 5. Tenant resolution
+
+- **UI / browser → by Host.** `files.diyetlif.com.tr` → provider `diyetlif` →
+  authenticate with that realm's OIDC. Each tenant keeps its own domain, no extra
+  login page. Behind a proxy, resolve from a **trusted** `X-Forwarded-Host` only
+  (untrusted host header must not select a tenant).
+- **API / agents → by token.** `api_tokens` → `user_id` → `provider_id`. The
+  MCP/agent path is tenant-scoped without any host.
+
+Both feed a single `TenantID`/`ProviderID` into the request context.
+
+## 6. Enforcement — one choke point, fail-closed
+
+Do **not** sprinkle `WHERE provider_id = ?` across handlers (miss one → leak).
+Put `provider_id` in the request context and wrap `db.Store` in a **scoped
+store** that injects the tenant filter into every tenant-scoped query, and
+**fails closed** (no tenant in context in mode-on → error). filex's small,
+hand-rolled `Store` interface makes this a single wrapper instead of dozens of
+edits.
+
+**Background work is storage-scoped, not request-scoped.** Sync, the queue
+(thumbs/ops/replica) and cron run outside any HTTP request — no host, no session.
+They already operate *on a storage/node*, so they derive tenancy from that
+storage, not from a context. The scoped-store wrapper is for the HTTP/API path;
+workers are storage-native and already isolated. Do not thread request-tenant
+context through workers.
+
+## 7. Auth & identity (JIT)
+
+- **First OIDC login → JIT-create** the user with `provider_id` = resolving
+  provider, `oidc_subject` from the token. The tag is **immutable** (a user can't
+  hop tenants).
+- Uniqueness is **`(provider_id, email)`** and **`(provider_id, oidc_subject)`**,
+  not global — two tenants may both have `admin@`.
+- Role/scope: reuse the existing OIDC claim→role logic (roles read from *both*
+  id_token and access_token, dotted-path `admin_group`). `scope = platform if
+  provider.is_supertenant else tenant`.
+
+## 8. Supertenant & super-admin
+
+Super-admin is **not** a special mechanism — it's a provider flag:
+
+- `providers.is_supertenant = true` → its admins are **platform-scoped** (see all
+  tenants). Same JIT/admin_group path; the flag only changes what "admin" *means*.
+- **Guardrails:**
+  - Supertenant is **confine-exempt + platform-scoped**; it may optionally have
+    its own storage (owner-org that is also ops), but that is orthogonal.
+  - **At most one** supertenant (enforced).
+  - Keep a **local bootstrap super-admin** (bcrypt) — chicken-and-egg (you need
+    super-admin to configure the supertenant provider) + break-glass if the realm
+    is down. Supertenant realm = daily ops; local admin = setup + emergency.
+  - Supertenant realm should be a hardened, separate Keycloak realm; whoever owns
+    it owns the platform. Tight `admin_group`.
+  - Every cross-tenant super-admin action is **loudly audited**.
+
+## 9. Admin scoping change (biggest behaviour delta)
+
+Today `admin` is RBAC-exempt and sees **all** storages. In mode-on, a
+**tenant-admin sees only their linked storages/users/audit**; only the
+supertenant sees all. So `storages.list`, the user directory, audit, etc. filter
+by the requester's provider. Gate this behind the mode so single-tenant admins
+are unchanged.
+
+## 10. Isolation checklist (the periphery that leaks if forgotten)
+
+- [ ] **Search (bleve)** — filter hits to the requester's accessible
+      `storage_id`s. *The #1 forgotten leak*; unfiltered search leaks content, not
+      just names.
+- [ ] **All pickers server-filtered** — user directory, storage-picker,
+      share-picker, grant-picker (RBAC), audit, notifications, search. The
+      negative-test matrix walks exactly this list.
+- [ ] **Shared sidecars (OnlyOffice/convert)** — doc keys must be unguessable and
+      storage derived server-side from the node (not client-supplied). Shared JWT
+      secret means isolation rests entirely on doc-key→node→storage.
+- [ ] **`/api/capabilities`** (pre-auth, host-resolved) — return only *this*
+      tenant's branding/features; never reveal other tenants exist.
+- [ ] **Public shares (`/s/{token}`) are intentionally host-agnostic** — a link
+      is a link; the file stays confined via token→node→storage. Drop/upload
+      (`/d/{token}`) confines the same way; client can't override storage.
+
+## 11. Tenant lifecycle
+
+- **Create (provisioning):** super-admin API → provider row + first admin +
+  optional default storage (mirror work.brf.sh `TenantCreated`/provisioner).
+- **Suspend:** disable login, keep data (billing/hold).
+- **Delete:** cascade — users, storages (nodes/shares/grants/sync_runs/thumbs
+  inherit via storage), tokens, audit. Get the cascade order right or you orphan
+  rows. Needed for GDPR "delete this tenant".
+
+## 12. Per-tenant settings & branding
+
+Each tenant on its own host wants its own `site_name`, logo, default locale,
+external-service URLs, and mail sender identity. `settings` gains a nullable
+`provider_id` (null = global); the host-resolved `/api/capabilities` returns the
+tenant's branding. Ties into `FILEX_DEFAULT_LOCALE` (already shipped).
+
+## 13. Deploy (Compose & Helm)
+
+- **Compose:** `deploy/compose/docker-compose.multi-tenant.yml` — a worked
+  2-tenant example (per-host proxy vhosts + provisioning steps in the header).
+- **Helm:** `ingress.extraHosts: [{host, tlsSecretName}]` in
+  `deploy/helm/filex/values.yaml` — one Ingress rule + TLS cert per tenant
+  host (cert-manager per host / SNI), all routed to the same filex.
+- **Trusted Host (security):** filex resolves the tenant from the `Host` header
+  the proxy forwards (Caddy/nginx/Ingress pass it through by default). Route
+  only trusted hosts to filex; don't expose it directly to arbitrary Host
+  values. (Even a spoofed host only reaches that tenant's login page — OIDC
+  creds + storage confinement are separate layers — but keep the front door
+  strict anyway.)
+
+## 14. Test matrix
+
+- **Negative isolation** (run in **both** modes): realm A user cannot see realm
+  B's users / storages / nodes / shares / search hits — one case per picker in
+  the §10 checklist.
+- **Mode-off byte-identical**: mode-off behaviour equals the pre-feature build.
+
+## 15. v2 / open
+
+- Per-tenant quota (extend per-user `user_quota` to a tenant total).
+- Per-tenant SMTP / webhook (v1 does per-tenant *sender identity* via branding).
+- DB-per-tenant option (stronger isolation, N× migrations/backups) vs the
+  shared-DB default here.
+
+---
+
+## Phased roadmap
+
+- [x] **Phase 1 — schema foundation.** `providers` + `provider_storages` tables,
+      `users.provider_id`/`oidc_subject`, default-provider backfill (00014 ×3),
+      `model.Provider`, `config.MultiTenant` flag. Additive, inert, mode-off
+      unchanged. *(verified: sqlite migration applies, backend builds, tests green.)*
+- [x] **Phase 2 — provider store + resolver.** Provider CRUD (sqlite+postgres,
+      mysql inherits) + `provider_storages` links + `GetProviderIDForStorage`;
+      `auth.TenantResolver` (user.provider_id → context Scope) wired into the
+      authed/admin/AI groups; `model.User` reads `provider_id`/`oidc_subject`.
+      *(verified: `provider_test.go` — CRUD, host resolution, links, reverse lookup.)*
+- [x] **Phase 3 — scoped store.** `tenantstore.Store` confines storage listings
+      to the scope; resolver fails CLOSED (`tenant.DenyAll`); handlers get the
+      scoped store, workers keep raw. *(verified: `store_test.go`.)*
+- [x] **Phase 4 — auth/JIT.** (4a) every user auto-joins the default
+      (supertenant) provider; `SetUserProvider` (JIT re-home) +
+      `GetUserByProviderEmail`; **maintenance mode** + **suspend** in
+      `auth.LoginAllowed`, wired into local + OIDC login. (4b)
+      `multioidc.Dispatcher`: request host → provider row → lazily-initialised,
+      config-cached per-realm `oidc.Driver` (`SetProviderID`); JIT lookup is
+      provider-scoped, new users are stamped with the tenant + subject, the tag
+      is immutable (cross-tenant email cannot hop realms), unknown hosts fall
+      back to the config-file realm. *(verified: `user_provider_test.go`;
+      ⚠ live multi-realm Keycloak E2E still to be exercised on a real deploy.)*
+      `(provider_id,email)` unique swap (00015) stays a review-gated migration
+      (not required for isolation; only for same-email across tenants).
+- [x] **Phase 5 — supertenant + admin scoping.** Confine-exempt platform scope;
+      at-most-one flag enforced by TRANSFER semantics (setting it on another
+      provider un-flags the old holder; direct un-flag/disable/delete of the
+      supertenant refused); local bootstrap admin (first-run) = break-glass.
+      Tenant-admin sees only its own storages/users/lists.
+- [x] **Phase 6 — isolation close-out.** User directory (permission/grant
+      picker), search hits, browse-adapter gate, admin shares/audit/grants
+      lists, per-tenant capabilities — all scope-filtered; sidecar doc keys were
+      already server-derived from the node. Negative tests: tenant A ≠ tenant B
+      for users + storages; DenyAll sees nothing.
+- [x] **Phase 7 — lifecycle API.** `/api/admin/providers`: provision, suspend
+      (enabled=false ⇒ login refused both modes), delete (+`?force=1` user
+      cascade; storage rows/files never touched), storage link/unlink;
+      supertenant-only management gate in multi-tenant mode. *(Admin SPA page
+      for it: pending — API-first.)*
+- [~] **Phase 8 — settings/branding.** Host-resolved `/api/capabilities` carries
+      `tenant {slug,name}` and never reveals other tenants. Full per-tenant
+      branding (`settings.provider_id`, logo/site_name/mail identity) = v2.
+- [x] **Phase 9 — deploy + docs.** `docker-compose.multi-tenant.yml`, Helm
+      `ingress.extraHosts` (per-host TLS), trusted-host note (§13).
+- [~] **Phase 10 — test matrix & CI.** Negative isolation green (users,
+      storages, lifecycle guards, suspend, maintenance mode); mode-off = full
+      pre-existing suite green (25 pkgs). PENDING: postgres/mysql migration CI
+      job, live multi-realm E2E, PR/review.


### PR DESCRIPTION
One install, N tenants. **provider = tenant**: an auth realm (OIDC/local) bound to a host, linked to its storages. Realm X signs in on its own domain and sees only storage X — even admins. Users of other realms are invisible, including on the permission/grant picker.

**Off by default** — `FILEX_MULTI_TENANT` unset ⇒ single-tenant behaviour is unchanged (the tenant scope simply never attaches). Turning it off later with tenants present = maintenance mode (supertenant-only login, data intact, reversible).

Design + phased status: `docs/MULTI-TENANCY.md` (two-layer isolation: file data via storage confinement, directory via provider scoping — a directory bug can leak at most a name, never file bytes).

Known pending (named in the doc): postgres/mysql migration CI, live multi-realm Keycloak E2E, admin SPA page for the providers API, `(provider_id,email)` unique-swap migration, full per-tenant branding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)