### PR TITLE
fix: uploads, /dav tenant isolation, quota + user management (olivov v0.8.0 report)

### DIFF
--- a/backend/db/migrations/mysql/00022_user_enabled.sql
+++ b/backend/db/migrations/mysql/00022_user_enabled.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Per-user on/off switch (olivov G4). Cuts a user's access without deleting
+-- the account: a disabled user cannot start a session (auth.LoginAllowed
+-- refuses them on local login, OIDC and /dav alike) while their files, quota
+-- and grants stay exactly where they are.
+--
+-- Defaults to enabled so every existing row keeps working.
+ALTER TABLE users ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN enabled;

--- a/backend/db/migrations/postgres/00022_user_enabled.sql
+++ b/backend/db/migrations/postgres/00022_user_enabled.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Per-user on/off switch (olivov G4). Cuts a user's access without deleting
+-- the account: a disabled user cannot start a session (auth.LoginAllowed
+-- refuses them on local login, OIDC and /dav alike) while their files, quota
+-- and grants stay exactly where they are.
+--
+-- Defaults to enabled so every existing row keeps working.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN IF EXISTS enabled;

--- a/backend/db/migrations/sqlite/00022_user_enabled.sql
+++ b/backend/db/migrations/sqlite/00022_user_enabled.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Per-user on/off switch (olivov G4). Cuts a user's access without deleting
+-- the account: a disabled user cannot start a session (auth.LoginAllowed
+-- refuses them on local login, OIDC and /dav alike) while their files, quota
+-- and grants stay exactly where they are.
+--
+-- Defaults to enabled so every existing row keeps working.
+ALTER TABLE users ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN enabled;

--- a/backend/internal/api/handlers/ai_admin.go
+++ b/backend/internal/api/handlers/ai_admin.go
@@ -123,7 +123,7 @@ func (a *AIAdmin) elevatedPrincipal(u *model.User) *model.User {
 	if u != nil && u.IsAdmin() {
 		return u
 	}
-	cp := model.User{Role: model.RoleAdmin, Email: "ai-admin-token"}
+	cp := model.User{Role: model.RoleAdmin, Email: "ai-admin-token", Enabled: true}
 	if u != nil {
 		cp = *u
 		cp.Role = model.RoleAdmin

--- a/backend/internal/api/handlers/auth.go
+++ b/backend/internal/api/handlers/auth.go
@@ -66,6 +66,17 @@ func (h *Auth) Login(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
 		return
 	}
+	// A disabled account is refused on its own terms. Folding it into the
+	// maintenance branch below would tell the user the whole platform is
+	// locked down when in fact only their account is.
+	if !user.Enabled {
+		_ = h.Store.DeleteSession(r.Context(), token)
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"error":    "this account is disabled",
+			"disabled": true,
+		})
+		return
+	}
 	if !auth.LoginAllowed(r.Context(), h.Store, h.MultiTenant, user) {
 		// Maintenance mode: multi-tenant is off but tenants exist — only the
 		// supertenant may sign in. See docs/MULTI-TENANCY.md.

--- a/backend/internal/api/handlers/auth_tenant_test.go
+++ b/backend/internal/api/handlers/auth_tenant_test.go
@@ -72,7 +72,7 @@ func TestOIDCCallback_MultiTenant_RedirectsToTenantHost(t *testing.T) {
 	// Set-Cookie), the session cookie scoped to the tenant apex (derived from
 	// the provider host), and a relative /admin/ target that stays on the
 	// tenant host that served the callback.
-	a = handlers.NewAuth(store, nil, &fakeOIDC{user: &model.User{ID: 1, Email: "u@tenant-a.test"}, token: "tkn"}, "https://operator.test", true, "")
+	a = handlers.NewAuth(store, nil, &fakeOIDC{user: &model.User{ID: 1, Email: "u@tenant-a.test", Enabled: true}, token: "tkn"}, "https://operator.test", true, "")
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?code=x&state=y", nil)
 	req.Host = "files.tenant-a.test"
 	rec := httptest.NewRecorder()
@@ -98,7 +98,7 @@ func TestOIDCCallback_MultiTenant_ExplicitCookieDomain_EmitsSetCookie(t *testing
 	})
 	tok := "aB3-cD_9xyZ012ABCdef-gh_"
 	a := handlers.NewAuth(store, nil,
-		&fakeOIDC{user: &model.User{ID: 1, Email: "u@tenant.example"}, token: tok},
+		&fakeOIDC{user: &model.User{ID: 1, Email: "u@tenant.example", Enabled: true}, token: tok},
 		"https://operator.example", true, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?code=x&state=y", nil)
@@ -121,7 +121,7 @@ func TestOIDCCallback_MultiTenant_ExplicitCookieDomain_EmitsSetCookie(t *testing
 // strips the callback's Set-Cookie in multi-tenant mode.
 func TestRouter_OIDCCallback_MultiTenant_EmitsSetCookie(t *testing.T) {
 	tok := "aB3-cD_9xyZ012ABCdef-gh_"
-	fake := &fakeOIDC{user: &model.User{ID: 1, Email: "u@tenant.example"}, token: tok}
+	fake := &fakeOIDC{user: &model.User{ID: 1, Email: "u@tenant.example", Enabled: true}, token: tok}
 	srv, client, store := testutil.NewTestServerWith(t,
 		func(c *config.Config) { c.MultiTenant = true },
 		func(d *api.Deps) { d.OIDCAuth = fake },

--- a/backend/internal/api/handlers/grants.go
+++ b/backend/internal/api/handlers/grants.go
@@ -76,20 +76,37 @@ func (h *Grants) resolvePath(w http.ResponseWriter, r *http.Request, raw string)
 		return nil, "", false
 	}
 	adapter, rel := splitAdapterPath(raw)
+	// Elsewhere in the API an unqualified path falls back to storages[0], but
+	// a grant is durable authorization state and guessing its storage is not
+	// recoverable by looking again. olivov posted {"path":"/deneme"} and
+	// watched the grant land on a different tenant's storage; adding a
+	// `storage` / `storage_id` field to the body changed nothing, because no
+	// such field is read (H6, 2026-08-05). Say which storage.
 	if adapter == "" {
-		storages, err := h.Store.ListEnabledStorages(r.Context())
-		if err != nil || len(storages) == 0 {
-			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "no storages"})
-			return nil, "", false
-		}
-		adapter = storages[0].Name
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": `path must name a storage, e.g. "Dosyalar://klasor"`,
+		})
+		return nil, "", false
 	}
 	st, err := h.Store.GetStorageByName(r.Context(), adapter)
-	if err != nil || st == nil {
+	// GetStorageByName is not one of the methods tenantstore confines, so the
+	// tenant gate is applied here. Out-of-tenant reads as unknown — same
+	// answer as a name that doesn't exist, so this isn't an existence oracle.
+	if err != nil || st == nil || !scopeOf(r.Context()).CanAccessStorage(st.ID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown adapter: " + adapter})
 		return nil, "", false
 	}
 	return st, acl.CleanRel(rel), true
+}
+
+// scopeOf returns the request's tenant scope; a nil scope means "unscoped"
+// (single-tenant mode) and reaches everything, per tenant.Scope's contract.
+func scopeOf(ctx context.Context) *tenant.Scope {
+	s, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return s
 }
 
 // requireEditor reports whether the caller may write/share at (st, rel):

--- a/backend/internal/api/handlers/grants_path_test.go
+++ b/backend/internal/api/handlers/grants_path_test.go
@@ -1,0 +1,68 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// TestGrants_UnqualifiedPathIsRejected — POST /api/files/permissions with a
+// bare "/deneme" silently fell back to storages[0] and wrote the grant
+// there. olivov watched a grant meant for their own storage land on a
+// different tenant's (H6, 2026-08-05); a `storage`/`storage_id` field in the
+// body changed nothing, because there is no such field.
+//
+// A grant is durable authorization state, so guessing the storage is the
+// wrong move: say which one.
+func TestGrants_UnqualifiedPathIsRejected(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	first := createRBACStorage(t, srv.URL, client, "BirinciDepo")
+	second := createRBACStorage(t, srv.URL, client, "IkinciDepo")
+	require.NotEqual(t, first, second)
+
+	target := createUser(t, srv.URL, client, "hedef@test.local", "HedefPass!1", "user")
+
+	t.Run("unqualified is a 400", func(t *testing.T) {
+		status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/files/permissions",
+			map[string]any{"path": "/deneme", "user_id": target, "level": "viewer", "is_dir": true})
+		require.Equal(t, http.StatusBadRequest, status,
+			"an unqualified path must be refused, not resolved to the first storage (%v)", body)
+	})
+
+	t.Run("qualified still works", func(t *testing.T) {
+		status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/files/permissions",
+			map[string]any{"path": "IkinciDepo://deneme", "user_id": target, "level": "viewer", "is_dir": true})
+		require.Equal(t, http.StatusOK, status, "%v", body)
+		require.Equal(t, float64(second), body["storage_id"],
+			"the grant must land on the storage the path named")
+	})
+}
+
+// createRBACStorage makes an RBAC-enabled local storage and returns its id.
+func createRBACStorage(t *testing.T, baseURL string, client *http.Client, name string) int64 {
+	t.Helper()
+	status, raw := doReq(t, client, http.MethodPost, baseURL+"/api/admin/storages", model.Storage{
+		Name:        name,
+		Driver:      "local",
+		MountPath:   "/" + name,
+		ConfigJSON:  json.RawMessage(`{"path":"` + t.TempDir() + `"}`),
+		SyncMode:    model.SyncModeOnDemand,
+		Enabled:     true,
+		RBACEnabled: true,
+	})
+	require.Equal(t, http.StatusOK, status, "create storage %s: %s", name, raw)
+	var st struct {
+		ID int64 `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &st))
+	require.NotZero(t, st.ID)
+	return st.ID
+}

--- a/backend/internal/api/handlers/manager_mutate.go
+++ b/backend/internal/api/handlers/manager_mutate.go
@@ -562,20 +562,28 @@ func (h *Manager) vfUpload(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Sniff the first 512 bytes for mime detection, then prepend
-		// them back so the driver receives the full payload. ZIP-based
+		// Sniff the first 512 bytes for mime detection, then rewind. ZIP-based
 		// office formats get refined via storage.RefineOfficeMime so
 		// pptx/docx/odt don't end up tagged "application/zip" — see
 		// internal/storage/mime.go for the OnlyOffice mismatch story.
+		//
+		// Rewind rather than io.MultiReader(sniff, src): multipart.File is an
+		// io.Seeker, and handing the driver a seekable body keeps the S3 SDK
+		// able to measure and to replay it on retry. Wrapping it cost us both
+		// and put every upload on the chunked path (olivov H1, 2026-08-05).
 		var sniff [512]byte
 		n, _ := io.ReadFull(src, sniff[:])
 		mime := ""
 		if n > 0 {
 			mime = storage.RefineOfficeMime(http.DetectContentType(sniff[:n]), name)
 		}
-		merged := io.MultiReader(bytes.NewReader(sniff[:n]), src)
+		if _, err := src.Seek(0, io.SeekStart); err != nil {
+			_ = src.Close()
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "rewind part: " + err.Error()})
+			return
+		}
 
-		if err := wr.Write(r.Context(), fullRel, merged, fh.Size); err != nil {
+		if err := wr.Write(r.Context(), fullRel, src, fh.Size); err != nil {
 			_ = src.Close()
 			writeJSON(w, mapDriverErr(err), map[string]string{"error": "write: " + err.Error()})
 			return

--- a/backend/internal/api/handlers/quota.go
+++ b/backend/internal/api/handlers/quota.go
@@ -2,13 +2,21 @@
 //
 // Endpoints:
 //
-//	GET  /api/auth/me/quota                              (auth)
+//	GET   /api/auth/me/quota                             (auth)
+//	GET   /api/admin/users/{id}/quota                    (admin)
+//	POST  /api/admin/users/{id}/quota                    (admin)
 //	PATCH /api/admin/users/{id}/quota                    (admin)
-//	POST /api/admin/users/{id}/quota/recompute           (admin)
+//	POST  /api/admin/users/{id}/quota/recompute          (admin)
+//
+// The flat forms — /api/admin/quota/{user_id} and
+// /api/admin/quota/{user_id}/recompute — are the original spelling and are
+// still served. Note both take a USER id: there is no per-provider quota
+// (see docs/MULTI-TENANCY.md, "Not yet").
 package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -26,6 +34,32 @@ type Quota struct {
 // NewQuota constructs the handler.
 func NewQuota(svc *quota.Service) *Quota { return &Quota{Service: svc} }
 
+// quotaUserID reads the target user id from whichever route mounted the
+// handler: /api/admin/quota/{user_id} or the nested, more discoverable
+// /api/admin/users/{id}/quota.
+func quotaUserID(r *http.Request) (int64, bool) {
+	raw := chi.URLParam(r, "user_id")
+	if raw == "" {
+		raw = chi.URLParam(r, "id")
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+// quotaErrStatus keeps "no such user" out of the 500 bucket. Reading a quota
+// for an id that isn't a user is a client mistake, not a server fault, and
+// answering 500 `sql: no rows in result set` told olivov nothing about the
+// real problem — they were passing provider ids to a user endpoint (H5).
+func quotaErrStatus(err error) int {
+	if errors.Is(err, quota.ErrUserNotFound) {
+		return http.StatusNotFound
+	}
+	return http.StatusInternalServerError
+}
+
 // Me returns the caller's quota snapshot.
 func (h *Quota) Me(w http.ResponseWriter, r *http.Request) {
 	u := auth.UserFrom(r.Context())
@@ -35,7 +69,7 @@ func (h *Quota) Me(w http.ResponseWriter, r *http.Request) {
 	}
 	snap, err := h.Service.Get(r.Context(), u.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, quotaErrStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, snap)
@@ -49,14 +83,14 @@ type setQuotaReq struct {
 // (The admin routes bind {user_id}; reading "id" here was a long-standing
 // mismatch that made these endpoints always 400 — fixed alongside.)
 func (h *Quota) AdminGet(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "user_id"), 10, 64)
-	if err != nil || id <= 0 {
+	id, ok := quotaUserID(r)
+	if !ok {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad id"})
 		return
 	}
 	snap, err := h.Service.Get(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, quotaErrStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, snap)
@@ -64,8 +98,8 @@ func (h *Quota) AdminGet(w http.ResponseWriter, r *http.Request) {
 
 // AdminSet writes a new quota_bytes for the target user.
 func (h *Quota) AdminSet(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "user_id"), 10, 64)
-	if err != nil || id <= 0 {
+	id, ok := quotaUserID(r)
+	if !ok {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad id"})
 		return
 	}
@@ -79,7 +113,7 @@ func (h *Quota) AdminSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.Service.SetQuota(r.Context(), id, req.QuotaBytes); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, quotaErrStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 	snap, _ := h.Service.Get(r.Context(), id)
@@ -88,14 +122,14 @@ func (h *Quota) AdminSet(w http.ResponseWriter, r *http.Request) {
 
 // AdminRecompute rescans nodes owned by id and rewrites usage_bytes.
 func (h *Quota) AdminRecompute(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(chi.URLParam(r, "user_id"), 10, 64)
-	if err != nil || id <= 0 {
+	id, ok := quotaUserID(r)
+	if !ok {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad id"})
 		return
 	}
 	used, err := h.Service.Recompute(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, quotaErrStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/backend/internal/api/handlers/quota_admin_test.go
+++ b/backend/internal/api/handlers/quota_admin_test.go
@@ -1,0 +1,70 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// TestAdminQuota_UnknownUserIs404 — /api/admin/quota/{user_id} used to answer
+// 500 {"error":"sql: no rows in result set"} for an id that isn't a user.
+// usage_bytes/quota_bytes are COALESCE'd columns on `users`, so no-rows can
+// only mean "no such user" — that's a 404, not a server fault.
+//
+// olivov hit this reading the endpoint with *provider* ids (H5, 2026-08-05);
+// a 500 gave them nothing to go on, which is the actual cost of the bug.
+func TestAdminQuota_UnknownUserIs404(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{"get", http.MethodGet, "/api/admin/quota/424242", nil},
+		{"set", http.MethodPost, "/api/admin/quota/424242", map[string]any{"quota_bytes": 1024}},
+		{"recompute", http.MethodPost, "/api/admin/quota/424242/recompute", nil},
+		{"nested get", http.MethodGet, "/api/admin/users/424242/quota", nil},
+		{"nested set", http.MethodPost, "/api/admin/users/424242/quota", map[string]any{"quota_bytes": 1024}},
+		{"nested recompute", http.MethodPost, "/api/admin/users/424242/quota/recompute", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := doJSON(t, client, tc.method, srv.URL+tc.path, tc.body)
+			if status != http.StatusNotFound {
+				t.Fatalf("want 404 for unknown user, got %d (%v)", status, body)
+			}
+		})
+	}
+}
+
+// TestAdminQuota_ExistingUserWithoutQuota — a real user who has never had a
+// quota set reads back as unlimited with a 200, not an error.
+func TestAdminQuota_ExistingUserWithoutQuota(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	ctx := context.Background()
+
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+	admin, err := store.GetUserByEmail(ctx, email)
+	if err != nil {
+		t.Fatalf("lookup seeded admin: %v", err)
+	}
+
+	status, body := doJSON(t, client, http.MethodGet,
+		fmt.Sprintf("%s/api/admin/quota/%d", srv.URL, admin.ID), nil)
+	if status != http.StatusOK {
+		t.Fatalf("want 200, got %d (%v)", status, body)
+	}
+	if body["unlimited"] != true {
+		t.Fatalf("want unlimited=true, got %v", body["unlimited"])
+	}
+	if body["quota_bytes"] != float64(0) {
+		t.Fatalf("want quota_bytes=0, got %v", body["quota_bytes"])
+	}
+}

--- a/backend/internal/api/handlers/users.go
+++ b/backend/internal/api/handlers/users.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/auth/drivers/local"
 	"github.com/brf-tech/filex/backend/internal/db"
 	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 )
 
 // Users handles /api/admin/users.
@@ -56,6 +57,43 @@ type userCreateReq struct {
 	Role        string `json:"role"`
 	Locale      string `json:"locale"`
 	Timezone    string `json:"timezone"`
+	// ProviderID homes the new user in a tenant. Optional; when absent the
+	// caller's own tenant is used.
+	ProviderID *int64 `json:"provider_id,omitempty"`
+}
+
+// resolveProvider decides which provider a created/updated user belongs to
+// and whether the caller may put them there. It returns the provider id to
+// write (0 = leave the store's own default alone), or an HTTP status + message.
+//
+// Store.CreateUser defaults provider_id to 1, and provider 1 (`default`) is
+// the SUPERTENANT — so "unspecified" used to mean "confine-exempt, sees every
+// tenant's storages". A tenant admin's new users therefore default to that
+// admin's own tenant, and only a supertenant caller may name an arbitrary one
+// (olivov G1, 2026-08-05).
+func (h *Users) resolveProvider(ctx context.Context, requested *int64) (int64, int, string) {
+	scope, scoped := tenant.FromContext(ctx)
+	confined := scoped && !scope.IsSupertenant
+
+	var target int64
+	if confined {
+		target = scope.ProviderID
+	}
+	if requested != nil {
+		if confined && *requested != scope.ProviderID {
+			return 0, http.StatusForbidden, "cannot assign a user to another tenant"
+		}
+		target = *requested
+	}
+	if target == 0 {
+		return 0, 0, "" // single-tenant / unscoped and nothing asked for
+	}
+	// provider_id carries no foreign key, so an unchecked value would strand
+	// the user in a tenant that does not exist.
+	if p, err := h.Store.GetProvider(ctx, target); err != nil || p == nil {
+		return 0, http.StatusBadRequest, "unknown provider_id"
+	}
+	return target, 0, ""
 }
 
 // Create makes a new user.
@@ -83,6 +121,13 @@ func (h *Users) Create(w http.ResponseWriter, r *http.Request) {
 	if req.Timezone == "" {
 		req.Timezone = "UTC"
 	}
+	// Resolve the tenant BEFORE creating anything, so a rejected provider_id
+	// doesn't leave a half-provisioned user behind.
+	providerID, status, msg := h.resolveProvider(r.Context(), req.ProviderID)
+	if status != 0 {
+		writeJSON(w, status, map[string]string{"error": msg})
+		return
+	}
 	hash, err := local.HashPassword(req.Password)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -92,6 +137,13 @@ func (h *Users) Create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+	if providerID != 0 {
+		if err := h.Store.SetUserProvider(r.Context(), u.ID, providerID, ""); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		u.ProviderID = &providerID
 	}
 	if name := strings.TrimSpace(req.DisplayName); name != "" {
 		if err := h.Store.UpdateUserDisplayName(r.Context(), u.ID, name); err == nil {
@@ -107,6 +159,9 @@ type userUpdateReq struct {
 	Role        *string `json:"role,omitempty"`
 	Locale      *string `json:"locale,omitempty"`
 	Timezone    *string `json:"timezone,omitempty"`
+	// ProviderID re-homes the user into another tenant. Supertenant only —
+	// see Update.
+	ProviderID *int64 `json:"provider_id,omitempty"`
 }
 
 // Update modifies a user. Only fields present in the body are touched.
@@ -134,6 +189,27 @@ func (h *Users) Update(w http.ResponseWriter, r *http.Request) {
 				writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot demote the last admin"})
 				return
 			}
+		}
+	}
+	// Re-homing a user between tenants is a platform-operator action, so it is
+	// restricted to an unscoped or supertenant caller. Letting a tenant admin
+	// do it would be an escalation in the other direction: Update has no
+	// ownership check on its target, so they could pull another tenant's user
+	// into their own tenant. It exists to repair accounts stranded in
+	// provider 1 by the create-side bug (G1).
+	if req.ProviderID != nil {
+		scope, scoped := tenant.FromContext(r.Context())
+		if scoped && !scope.IsSupertenant {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "only the supertenant may move a user between tenants"})
+			return
+		}
+		if p, err := h.Store.GetProvider(r.Context(), *req.ProviderID); err != nil || p == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown provider_id"})
+			return
+		}
+		if err := h.Store.SetUserProvider(r.Context(), id, *req.ProviderID, ""); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
 		}
 	}
 	if req.Password != nil {

--- a/backend/internal/api/handlers/users.go
+++ b/backend/internal/api/handlers/users.go
@@ -162,6 +162,8 @@ type userUpdateReq struct {
 	// ProviderID re-homes the user into another tenant. Supertenant only —
 	// see Update.
 	ProviderID *int64 `json:"provider_id,omitempty"`
+	// Enabled gates whether the account may start a session.
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // Update modifies a user. Only fields present in the body are touched.
@@ -189,6 +191,15 @@ func (h *Users) Update(w http.ResponseWriter, r *http.Request) {
 				writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot demote the last admin"})
 				return
 			}
+		}
+	}
+	// Disabling the final admin locks everyone out of the admin surface just
+	// as surely as deleting or demoting them, both of which are already
+	// refused above.
+	if req.Enabled != nil && !*req.Enabled {
+		if last, err := h.isLastAdmin(r.Context(), id); err == nil && last {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot disable the last admin"})
+			return
 		}
 	}
 	// Re-homing a user between tenants is a platform-operator action, so it is
@@ -225,6 +236,12 @@ func (h *Users) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Role != nil {
 		_ = h.Store.UpdateUserRole(r.Context(), id, *req.Role)
+	}
+	if req.Enabled != nil {
+		if err := h.Store.SetUserEnabled(r.Context(), id, *req.Enabled); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
 	}
 	if req.Locale != nil || req.Timezone != nil {
 		// Fetch current to fill in the missing field.

--- a/backend/internal/api/handlers/users_enabled_test.go
+++ b/backend/internal/api/handlers/users_enabled_test.go
@@ -1,0 +1,174 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/auth/drivers/apitoken"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// loginStatus posts credentials and returns the status. testutil.LoginAs
+// t.Fatalf's on anything but 200, which is the wrong shape for asserting
+// that a login is REFUSED.
+func loginStatus(t *testing.T, client *http.Client, baseURL, email, password string) int {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	require.NoError(t, err)
+	resp, err := client.Post(baseURL+"/api/auth/login", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestAdminUsers_EnableDisable — cutting a user's file access without
+// deleting the account. olivov has the mail-side equivalent (Stalwart role
+// emptied) and needed the file-side one (G4, 2026-08-04).
+func TestAdminUsers_EnableDisable(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	ctx := context.Background()
+
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	const targetEmail, targetPass = "kisi@test.local", "TargetPass!1"
+	testutil.SeedRegularUser(t, store, targetEmail, targetPass)
+	target, err := store.GetUserByEmail(ctx, targetEmail)
+	require.NoError(t, err)
+
+	// login works while enabled
+	loginAs := func(t *testing.T) int {
+		t.Helper()
+		jar, err := cookiejar.New(nil)
+		require.NoError(t, err)
+		return loginStatus(t, &http.Client{Jar: jar}, srv.URL, targetEmail, targetPass)
+	}
+
+	t.Run("enabled by default", func(t *testing.T) {
+		status, body := doJSON(t, client, http.MethodGet,
+			fmt.Sprintf("%s/api/admin/users/%d", srv.URL, target.ID), nil)
+		require.Equal(t, http.StatusOK, status, "%v", body)
+		require.Equal(t, true, body["enabled"], "existing users must read back enabled")
+		require.Equal(t, http.StatusOK, loginAs(t))
+	})
+
+	t.Run("disable blocks login", func(t *testing.T) {
+		status, body := doJSON(t, client, http.MethodPatch,
+			fmt.Sprintf("%s/api/admin/users/%d", srv.URL, target.ID),
+			map[string]any{"enabled": false})
+		require.Equal(t, http.StatusOK, status, "%v", body)
+
+		status, body = doJSON(t, client, http.MethodGet,
+			fmt.Sprintf("%s/api/admin/users/%d", srv.URL, target.ID), nil)
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, false, body["enabled"])
+
+		// 403, not 401: the credentials are valid, the account isn't allowed
+		// in — the same shape a suspended tenant already gets.
+		require.Equal(t, http.StatusForbidden, loginAs(t),
+			"a disabled user must not be able to start a session")
+	})
+
+	t.Run("files are preserved", func(t *testing.T) {
+		// The account and everything hanging off it must survive; disable is
+		// not a soft delete.
+		u, err := store.GetUserByEmail(ctx, targetEmail)
+		require.NoError(t, err)
+		require.Equal(t, target.ID, u.ID)
+	})
+
+	t.Run("re-enable restores login", func(t *testing.T) {
+		status, body := doJSON(t, client, http.MethodPatch,
+			fmt.Sprintf("%s/api/admin/users/%d", srv.URL, target.ID),
+			map[string]any{"enabled": true})
+		require.Equal(t, http.StatusOK, status, "%v", body)
+		require.Equal(t, http.StatusOK, loginAs(t))
+	})
+}
+
+// TestAdminUsers_DisableKillsLiveAccess — disabling has to cut access the
+// user ALREADY holds, not just refuse the next login. Two ways in survive a
+// login gate on their own:
+//
+//   - a session cookie minted before the switch (auth.Middleware trusts
+//     whatever the driver resolves)
+//   - an API token (MiddlewareWithToken looks the user up and admits them)
+//
+// Either one leaves "disabled" meaning "disabled tomorrow".
+func TestAdminUsers_DisableKillsLiveAccess(t *testing.T) {
+	srv, adminClient, store := testutil.NewTestServer(t)
+	ctx := context.Background()
+
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, adminClient, email, password)
+
+	const targetEmail, targetPass = "kisi2@test.local", "TargetPass!1"
+	testutil.SeedRegularUser(t, store, targetEmail, targetPass)
+	target, err := store.GetUserByEmail(ctx, targetEmail)
+	require.NoError(t, err)
+
+	// A live session, established while enabled.
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	sessionClient := &http.Client{Jar: jar}
+	testutil.LoginAs(t, srv, sessionClient, targetEmail, targetPass)
+
+	// A live API token.
+	rawToken := "enabled-test-token-" + targetEmail
+	_, err = store.CreateAPIToken(ctx, &model.APIToken{
+		UserID: target.ID, Label: "enabled-test", TokenHash: apitoken.HashToken(rawToken),
+	})
+	require.NoError(t, err)
+
+	probe := func(t *testing.T, c *http.Client, token string) int {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/files/quota/me", nil)
+		require.NoError(t, err)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := c.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	require.Equal(t, http.StatusOK, probe(t, sessionClient, ""))
+	require.Equal(t, http.StatusOK, probe(t, &http.Client{}, rawToken))
+
+	status, body := doJSON(t, adminClient, http.MethodPatch,
+		fmt.Sprintf("%s/api/admin/users/%d", srv.URL, target.ID),
+		map[string]any{"enabled": false})
+	require.Equal(t, http.StatusOK, status, "%v", body)
+
+	require.Equal(t, http.StatusForbidden, probe(t, sessionClient, ""),
+		"an existing session must stop working once the account is disabled")
+	require.Equal(t, http.StatusForbidden, probe(t, &http.Client{}, rawToken),
+		"an API token must stop working once its owner is disabled")
+}
+
+// TestAdminUsers_CannotDisableLastAdmin — disabling the final admin locks
+// everyone out of the admin surface just as effectively as deleting them,
+// which Delete and Update already refuse.
+func TestAdminUsers_CannotDisableLastAdmin(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	ctx := context.Background()
+
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+	admin, err := store.GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	status, body := doJSON(t, client, http.MethodPatch,
+		fmt.Sprintf("%s/api/admin/users/%d", srv.URL, admin.ID),
+		map[string]any{"enabled": false})
+	require.Equal(t, http.StatusConflict, status, "%v", body)
+}

--- a/backend/internal/api/handlers/users_provider_test.go
+++ b/backend/internal/api/handlers/users_provider_test.go
@@ -1,0 +1,153 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/auth/drivers/local"
+	"github.com/brf-tech/filex/backend/internal/config"
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// multiTenantServer is a test server with multi-tenant mode on, which is what
+// makes auth.TenantResolver attach a scope to admin requests.
+func multiTenantServer(t *testing.T) (*httptest.Server, *http.Client, db.Store) {
+	t.Helper()
+	return testutil.NewTestServerCfg(t, func(c *config.Config) {
+		c.MultiTenant = true
+	})
+}
+
+// seedTenant creates an enabled provider plus an admin user homed in it, and
+// returns (providerID, email, password). Providers are created disabled and
+// auth.LoginAllowed refuses those, so Enabled matters.
+func seedTenant(t *testing.T, store db.Store, slug, email string, supertenant bool) (int64, string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	p, err := store.CreateProvider(ctx, &model.Provider{
+		Slug: slug, Name: slug, AuthType: "local", IsSupertenant: supertenant, Enabled: true,
+	})
+	require.NoError(t, err)
+
+	password := "TenantAdmin!1"
+	hash, err := local.HashPassword(password)
+	require.NoError(t, err)
+	u, err := store.CreateUser(ctx, email, hash, model.RoleAdmin, "en", "UTC")
+	require.NoError(t, err)
+	require.NoError(t, store.SetUserProvider(ctx, u.ID, p.ID, ""))
+
+	return p.ID, email, password
+}
+
+func providerOf(t *testing.T, store db.Store, userID int64) int64 {
+	t.Helper()
+	u, err := store.GetUser(context.Background(), userID)
+	require.NoError(t, err)
+	require.NotNil(t, u.ProviderID, "user %d has no provider", userID)
+	return *u.ProviderID
+}
+
+// TestCreateUser_HonoursProviderID — POST /api/admin/users dropped
+// provider_id on the floor (the request struct had no such field), so every
+// user created through the admin API landed in provider 1.
+//
+// Provider 1 is `default`, and `default` is the SUPERTENANT: the account
+// olivov meant to pre-provision for one tenant came out confine-exempt,
+// able to see every tenant's storages. Reported as a pre-provisioning gap
+// (G1, 2026-08-05); it is also a privilege one.
+func TestCreateUser_HonoursProviderID(t *testing.T) {
+	srv, client, store := multiTenantServer(t)
+	email, password := testutil.SeedAdmin(t, store) // provider 1 = supertenant
+	testutil.LoginAs(t, srv, client, email, password)
+
+	tenantID, _, _ := seedTenant(t, store, "diyetlif", "admin@diyetlif.test", false)
+
+	status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/admin/users", map[string]any{
+		"email": "rbac-probe@diyetlif.test", "password": "ProbePass!1",
+		"role": "user", "provider_id": tenantID,
+	})
+	require.Equal(t, http.StatusOK, status, "%v", body)
+
+	newID := int64(body["id"].(float64))
+	require.Equal(t, tenantID, providerOf(t, store, newID),
+		"the requested provider must be the one the user lands in")
+}
+
+// TestCreateUser_DefaultsToCallersProvider — with no provider_id, a tenant
+// admin's new user belongs to that admin's tenant. It used to default to
+// provider 1 (the supertenant) regardless of who was asking.
+func TestCreateUser_DefaultsToCallersProvider(t *testing.T) {
+	srv, client, store := multiTenantServer(t)
+	tenantID, email, password := seedTenant(t, store, "diyetlif", "admin@diyetlif.test", false)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/admin/users", map[string]any{
+		"email": "yeni@diyetlif.test", "password": "ProbePass!1", "role": "user",
+	})
+	require.Equal(t, http.StatusOK, status, "%v", body)
+
+	newID := int64(body["id"].(float64))
+	require.Equal(t, tenantID, providerOf(t, store, newID),
+		"a tenant admin's new user must stay inside that tenant")
+}
+
+// TestCreateUser_TenantAdminCannotPlantElsewhere — a tenant admin may not
+// create a user inside another tenant, nor inside the supertenant.
+func TestCreateUser_TenantAdminCannotPlantElsewhere(t *testing.T) {
+	srv, client, store := multiTenantServer(t)
+	_, email, password := seedTenant(t, store, "diyetlif", "admin@diyetlif.test", false)
+	otherID, _, _ := seedTenant(t, store, "arasboya", "admin@arasboya.test", false)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/admin/users", map[string]any{
+		"email": "planted@arasboya.test", "password": "ProbePass!1",
+		"role": "user", "provider_id": otherID,
+	})
+	require.Equal(t, http.StatusForbidden, status, "%v", body)
+}
+
+// TestCreateUser_UnknownProviderIs400 — a provider_id that names nothing is
+// a client error, not a silent fallback. provider_id has no FK, so an
+// unchecked value would strand the user where nothing can reach them.
+func TestCreateUser_UnknownProviderIs400(t *testing.T) {
+	srv, client, store := multiTenantServer(t)
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/admin/users", map[string]any{
+		"email": "nowhere@test.local", "password": "ProbePass!1",
+		"role": "user", "provider_id": 99999,
+	})
+	require.Equal(t, http.StatusBadRequest, status, "%v", body)
+}
+
+// TestUpdateUser_ReHomesProvider — the remediation path. Users already
+// created into provider 1 by the bug above need a way out, and until now no
+// admin endpoint could set a user's provider at all (only OIDC JIT did).
+func TestUpdateUser_ReHomesProvider(t *testing.T) {
+	srv, client, store := multiTenantServer(t)
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+
+	tenantID, _, _ := seedTenant(t, store, "diyetlif", "admin@diyetlif.test", false)
+
+	status, body := doJSON(t, client, http.MethodPost, srv.URL+"/api/admin/users", map[string]any{
+		"email": "stranded@diyetlif.test", "password": "ProbePass!1", "role": "user",
+	})
+	require.Equal(t, http.StatusOK, status, "%v", body)
+	newID := int64(body["id"].(float64))
+
+	status, body = doJSON(t, client, http.MethodPatch,
+		fmt.Sprintf("%s/api/admin/users/%d", srv.URL, newID),
+		map[string]any{"provider_id": tenantID})
+	require.Equal(t, http.StatusOK, status, "%v", body)
+	require.Equal(t, tenantID, providerOf(t, store, newID))
+}

--- a/backend/internal/api/handlers/users_usage_test.go
+++ b/backend/internal/api/handlers/users_usage_test.go
@@ -1,0 +1,67 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/testutil"
+)
+
+// TestAdminUsers_ExposeUsageAndQuota — "how much room is this user taking?"
+// had no answer on the user object: GET /api/admin/users/{id} returned
+// created_at, display_name, email, id, last_login_at, locale, provider_id,
+// role, timezone, totp_enabled, updated_at and nothing else, even though
+// users.usage_bytes and users.quota_bytes have existed since migration
+// 00003. Only the caller's own /quota/me could see them.
+//
+// olivov needs both in one call to fill a table (G3 + G2, 2026-08-04).
+func TestAdminUsers_ExposeUsageAndQuota(t *testing.T) {
+	srv, client, store := testutil.NewTestServer(t)
+	ctx := context.Background()
+
+	email, password := testutil.SeedAdmin(t, store)
+	testutil.LoginAs(t, srv, client, email, password)
+	admin, err := store.GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetUserQuota(ctx, admin.ID, 5*1024*1024*1024))
+	require.NoError(t, store.IncrementUserUsage(ctx, admin.ID, 1234))
+
+	t.Run("single user", func(t *testing.T) {
+		status, body := doJSON(t, client, http.MethodGet,
+			fmt.Sprintf("%s/api/admin/users/%d", srv.URL, admin.ID), nil)
+		require.Equal(t, http.StatusOK, status, "%v", body)
+		require.Equal(t, float64(1234), body["used_bytes"])
+		require.Equal(t, float64(5*1024*1024*1024), body["quota_bytes"])
+	})
+
+	t.Run("list", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/admin/users", nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var users []map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&users))
+		require.NotEmpty(t, users)
+
+		var found bool
+		for _, u := range users {
+			if int64(u["id"].(float64)) != admin.ID {
+				continue
+			}
+			found = true
+			require.Equal(t, float64(1234), u["used_bytes"],
+				"the list must carry usage too, so a table is one call")
+			require.Equal(t, float64(5*1024*1024*1024), u["quota_bytes"])
+		}
+		require.True(t, found, "seeded admin missing from the list")
+	})
+}

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -487,6 +487,15 @@ func BuildRouter(d *Deps) http.Handler {
 				r.Patch("/{id}", ush.Update)
 				r.Delete("/{id}", ush.Delete)
 				r.Post("/{id}/reset-password", usersAdmH.ResetPassword)
+				// Per-user quota, nested where callers look for it first.
+				// The flat /api/admin/quota/{user_id} below predates this and
+				// still works; handlers/quota.go has documented this nested
+				// shape since before it existed, which sent olivov hunting
+				// for a provider-quota endpoint that was never there (G2).
+				r.Get("/{id}/quota", quotaH.AdminGet)
+				r.Post("/{id}/quota", quotaH.AdminSet)
+				r.Patch("/{id}/quota", quotaH.AdminSet)
+				r.Post("/{id}/quota/recompute", quotaH.AdminRecompute)
 			})
 
 			r.Route("/settings", func(r chi.Router) {

--- a/backend/internal/auth/apitoken_middleware.go
+++ b/backend/internal/auth/apitoken_middleware.go
@@ -116,6 +116,14 @@ func MiddlewareWithToken(store db.Store, required bool) func(http.Handler) http.
 				if tok, err := store.GetAPITokenByHash(ctx, hashAPIToken(raw)); err == nil && tok != nil {
 					if tok.ExpiresAt == nil || tok.ExpiresAt.After(time.Now()) {
 						if user, err := store.GetUser(ctx, tok.UserID); err == nil && user != nil {
+							// A token outlives its owner's account status, so the
+							// disabled check (migration 00022) belongs here too:
+							// otherwise disabling a user leaves every token they
+							// ever minted working.
+							if !user.Enabled {
+								writeAuthErr(w, http.StatusForbidden, "this account is disabled")
+								return
+							}
 							// A username outside the token's allow-list is a hard
 							// error even on this hybrid chain — falling through to
 							// session auth would silently ignore the caller's

--- a/backend/internal/auth/login_policy.go
+++ b/backend/internal/auth/login_policy.go
@@ -18,11 +18,23 @@ import (
 //     single-tenant install is unaffected — its only provider IS the
 //     supertenant.
 //
-// It fails toward availability: a NULL provider (bootstrap/legacy admin) or an
-// unresolvable provider is allowed, so an operator is never locked out by a
-// glitch. Only a resolvable, non-supertenant tenant is ever refused.
+// One user-level gate:
+//   - DISABLED ACCOUNT: users.enabled = false (migration 00022) refuses the
+//     session outright, in both modes, with files/quota/grants untouched.
+//     Checked first so it holds in a plain single-tenant install too.
+//
+// Otherwise it fails toward availability: a NULL provider (bootstrap/legacy
+// admin) or an unresolvable provider is allowed, so an operator is never
+// locked out by a glitch. Only a resolvable, non-supertenant tenant is ever
+// refused.
 func LoginAllowed(ctx context.Context, store db.Store, multiTenant bool, u *model.User) bool {
-	if u == nil || u.ProviderID == nil {
+	if u == nil {
+		return true
+	}
+	if !u.Enabled {
+		return false
+	}
+	if u.ProviderID == nil {
 		return true
 	}
 	p, err := store.GetProvider(ctx, *u.ProviderID)

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -35,6 +35,19 @@ func Middleware(required bool) func(http.Handler) http.Handler {
 				}
 			}
 
+			// A disabled account (migration 00022) is refused even when a driver
+			// happily resolved it. A session minted before the switch would
+			// otherwise keep working until it expired, which makes "disabled"
+			// mean "disabled tomorrow".
+			if user != nil && !user.Enabled {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error": "this account is disabled",
+				})
+				return
+			}
+
 			if user == nil && required {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)

--- a/backend/internal/auth/tenant_middleware.go
+++ b/backend/internal/auth/tenant_middleware.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
 	"github.com/brf-tech/filex/backend/internal/tenant"
 )
 
@@ -35,20 +37,29 @@ func TenantResolver(store db.Store, multiTenant bool) func(http.Handler) http.Ha
 				next.ServeHTTP(w, r)
 				return
 			}
-			// Authenticated request in multi-tenant mode: ALWAYS attach a scope so
-			// the scoped store filters. A user whose provider is missing or
-			// unknown gets tenant.DenyAll (sees nothing) — fail closed, never a
-			// silent fall-through to "see everything".
-			scope := tenant.DenyAll
-			if u.ProviderID != nil {
-				if p, err := store.GetProvider(r.Context(), *u.ProviderID); err == nil && p != nil {
-					scope = &tenant.Scope{ProviderID: p.ID, Slug: p.Slug, IsSupertenant: p.IsSupertenant}
-					if !p.IsSupertenant {
-						scope.StorageIDs, _ = store.ListProviderStorageIDs(r.Context(), p.ID)
-					}
-				}
-			}
-			next.ServeHTTP(w, r.WithContext(tenant.WithScope(r.Context(), scope)))
+			next.ServeHTTP(w, r.WithContext(tenant.WithScope(r.Context(), ScopeForUser(r.Context(), store, u))))
 		})
 	}
+}
+
+// ScopeForUser resolves a user's tenant scope. Callers that authenticate
+// outside the middleware chain — /dav does its own Basic auth — use this to
+// attach the same scope the HTTP middleware would have.
+//
+// ALWAYS returns a non-nil scope so the scoped store filters. A user whose
+// provider is missing or unknown gets tenant.DenyAll (sees nothing) — fail
+// closed, never a silent fall-through to "see everything".
+func ScopeForUser(ctx context.Context, store db.Store, u *model.User) *tenant.Scope {
+	if u == nil || u.ProviderID == nil {
+		return tenant.DenyAll
+	}
+	p, err := store.GetProvider(ctx, *u.ProviderID)
+	if err != nil || p == nil {
+		return tenant.DenyAll
+	}
+	scope := &tenant.Scope{ProviderID: p.ID, Slug: p.Slug, IsSupertenant: p.IsSupertenant}
+	if !p.IsSupertenant {
+		scope.StorageIDs, _ = store.ListProviderStorageIDs(ctx, p.ID)
+	}
+	return scope
 }

--- a/backend/internal/dav/dav.go
+++ b/backend/internal/dav/dav.go
@@ -44,6 +44,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/model"
 	"github.com/brf-tech/filex/backend/internal/search"
 	"github.com/brf-tech/filex/backend/internal/storage"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 	"github.com/brf-tech/filex/backend/internal/thumb"
 )
 
@@ -129,6 +130,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("WWW-Authenticate", `Basic realm="`+h.cfg.Realm+`", charset="UTF-8"`)
 		http.Error(w, "authentication required", http.StatusUnauthorized)
 		return
+	}
+
+	// /dav authenticates itself (Basic), so it sits outside the chain where
+	// auth.TenantResolver runs: no tenant scope ever reached the scoped store,
+	// ListEnabledStorages saw an unscoped context, and the root listed every
+	// tenant's storages. Attach the scope the middleware would have.
+	//
+	// Until this, a tenant admin who mounted /dav got all ten olivov tenants
+	// read-write — and DELETE over WebDAV is permanent, it does not go to
+	// trash (H4, 2026-08-05).
+	if h.cfg.MultiTenant {
+		r = r.WithContext(tenant.WithScope(r.Context(),
+			auth.ScopeForUser(r.Context(), h.cfg.Store, p.user)))
 	}
 
 	if status, msg := h.preGate(r, p); status != 0 {

--- a/backend/internal/dav/dav.go
+++ b/backend/internal/dav/dav.go
@@ -48,6 +48,17 @@ import (
 	"github.com/brf-tech/filex/backend/internal/thumb"
 )
 
+// scopeOf returns the request's tenant scope. A nil scope means "unscoped"
+// (single-tenant mode, background work) and reaches everything, matching
+// tenant.Scope's own contract.
+func scopeOf(ctx context.Context) *tenant.Scope {
+	s, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return s
+}
+
 // Prefix is the URL prefix the handler is mounted at.
 const Prefix = "/dav"
 
@@ -317,8 +328,12 @@ func (h *Handler) preGate(r *http.Request, p *principal) (int, string) {
 	}
 
 	ctx := r.Context()
+	// Same tenant gate the FileSystem applies (GetStorageByName is not one of
+	// the methods tenantstore confines). Without it the pre-gate stays an
+	// oracle even though the data path is closed: a foreign read-only storage
+	// would answer 403 "read-only" where a non-existent one answers 404.
 	st, err := h.cfg.Store.GetStorageByName(ctx, name)
-	if err != nil || st == nil || !st.Enabled {
+	if err != nil || st == nil || !st.Enabled || !scopeOf(ctx).CanAccessStorage(st.ID) {
 		return http.StatusNotFound, "storage not found"
 	}
 	if status, msg := h.gateWrite(ctx, p, st, rel, r.Method); status != 0 {
@@ -342,7 +357,8 @@ func (h *Handler) preGate(r *http.Request, p *principal) (int, string) {
 		}
 		dst := st
 		if dname != name {
-			if dst, err = h.cfg.Store.GetStorageByName(ctx, dname); err != nil || dst == nil || !dst.Enabled {
+			if dst, err = h.cfg.Store.GetStorageByName(ctx, dname); err != nil || dst == nil || !dst.Enabled ||
+				!scopeOf(ctx).CanAccessStorage(dst.ID) {
 				return http.StatusConflict, "destination storage not found"
 			}
 		}

--- a/backend/internal/dav/fs.go
+++ b/backend/internal/dav/fs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/brf-tech/filex/backend/internal/acl"
 	"github.com/brf-tech/filex/backend/internal/model"
 	"github.com/brf-tech/filex/backend/internal/storage"
-	"github.com/brf-tech/filex/backend/internal/tenant"
 	"github.com/brf-tech/filex/backend/internal/trash"
 )
 
@@ -72,7 +71,7 @@ func (f *davFS) storageByName(ctx context.Context, name string) (*model.Storage,
 	// gate has to be applied here. ErrNotExist rather than ErrPermission
 	// keeps the no-exists-oracle rule — a foreign storage is indistinguishable
 	// from one that isn't there.
-	if !f.scope(ctx).CanAccessStorage(st.ID) {
+	if !scopeOf(ctx).CanAccessStorage(st.ID) {
 		return nil, nil, os.ErrNotExist
 	}
 	set, err := f.aclSet(ctx, st)
@@ -83,17 +82,6 @@ func (f *davFS) storageByName(ctx context.Context, name string) (*model.Storage,
 		return nil, nil, os.ErrNotExist
 	}
 	return st, set, nil
-}
-
-// scope returns the request's tenant scope. A nil scope means "unscoped"
-// (single-tenant mode, background work) and reaches everything, matching
-// tenant.Scope's own contract.
-func (f *davFS) scope(ctx context.Context) *tenant.Scope {
-	s, ok := tenant.FromContext(ctx)
-	if !ok {
-		return nil
-	}
-	return s
 }
 
 func (f *davFS) aclSet(ctx context.Context, st *model.Storage) (*acl.Set, error) {
@@ -440,7 +428,7 @@ func (f *davFS) rootDir(ctx context.Context) (webdav.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	scope := f.scope(ctx)
+	scope := scopeOf(ctx)
 	infos := make([]os.FileInfo, 0, len(storages))
 	for _, st := range storages {
 		// ListEnabledStorages is already tenant-confined when the store is

--- a/backend/internal/dav/fs.go
+++ b/backend/internal/dav/fs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/acl"
 	"github.com/brf-tech/filex/backend/internal/model"
 	"github.com/brf-tech/filex/backend/internal/storage"
+	"github.com/brf-tech/filex/backend/internal/tenant"
 	"github.com/brf-tech/filex/backend/internal/trash"
 )
 
@@ -66,6 +67,14 @@ func (f *davFS) storageByName(ctx context.Context, name string) (*model.Storage,
 	if err != nil || st == nil || !st.Enabled {
 		return nil, nil, os.ErrNotExist
 	}
+	// Name lookup is a by-name hit against every storage in the install:
+	// tenantstore confines the *list* methods, not this one, so the tenant
+	// gate has to be applied here. ErrNotExist rather than ErrPermission
+	// keeps the no-exists-oracle rule — a foreign storage is indistinguishable
+	// from one that isn't there.
+	if !f.scope(ctx).CanAccessStorage(st.ID) {
+		return nil, nil, os.ErrNotExist
+	}
 	set, err := f.aclSet(ctx, st)
 	if err != nil {
 		return nil, nil, err
@@ -74,6 +83,17 @@ func (f *davFS) storageByName(ctx context.Context, name string) (*model.Storage,
 		return nil, nil, os.ErrNotExist
 	}
 	return st, set, nil
+}
+
+// scope returns the request's tenant scope. A nil scope means "unscoped"
+// (single-tenant mode, background work) and reaches everything, matching
+// tenant.Scope's own contract.
+func (f *davFS) scope(ctx context.Context) *tenant.Scope {
+	s, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return s
 }
 
 func (f *davFS) aclSet(ctx context.Context, st *model.Storage) (*acl.Set, error) {
@@ -420,8 +440,15 @@ func (f *davFS) rootDir(ctx context.Context) (webdav.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	scope := f.scope(ctx)
 	infos := make([]os.FileInfo, 0, len(storages))
 	for _, st := range storages {
+		// ListEnabledStorages is already tenant-confined when the store is
+		// the scoped one; re-checking here keeps the root correct even if
+		// /dav is handed a raw store.
+		if !scope.CanAccessStorage(st.ID) {
+			continue
+		}
 		set, err := f.aclSet(ctx, st)
 		if err != nil || !set.StorageVisible() {
 			continue

--- a/backend/internal/dav/tenant_test.go
+++ b/backend/internal/dav/tenant_test.go
@@ -153,6 +153,17 @@ func TestDAV_TenantScoping(t *testing.T) {
 		resp := ha.req(t, http.MethodPut, "/dav/"+ownSt.Name+"/mine.txt", me, pass, "hello", nil)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 	})
+
+	// COPY resolves its Destination separately from the request path, in the
+	// pre-gate as well as the FileSystem. Both have to apply the tenant gate,
+	// or a caller could stream their own file into someone else's storage.
+	t.Run("cannot copy out to a foreign storage", func(t *testing.T) {
+		resp := ha.req(t, "COPY", "/dav/"+ownSt.Name+"/mine.txt", me, pass, "", map[string]string{
+			"Destination": "/dav/" + otherSt.Name + "/leaked.txt",
+		})
+		require.GreaterOrEqual(t, resp.StatusCode, 400,
+			"a copy whose destination is another tenant's storage must be refused")
+	})
 }
 
 // TestDAV_SupertenantSeesAll — "admin sees everything" stays true for an

--- a/backend/internal/dav/tenant_test.go
+++ b/backend/internal/dav/tenant_test.go
@@ -1,0 +1,226 @@
+package dav
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/acl"
+	"github.com/brf-tech/filex/backend/internal/auth/drivers/local"
+	"github.com/brf-tech/filex/backend/internal/db"
+	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/storage"
+	"github.com/brf-tech/filex/backend/internal/tenantstore"
+	"github.com/brf-tech/filex/backend/internal/testutil/dbtest"
+	"net/http/httptest"
+
+	_ "github.com/brf-tech/filex/backend/internal/storage/drivers/local"
+)
+
+// tenantHarness is newHarness in multi-tenant shape: the handler sees the
+// tenant-scoped store (as the server wires it) and MultiTenant is on.
+type tenantHarness struct {
+	*harness
+	raw db.Store
+}
+
+func newTenantHarness(t *testing.T) *tenantHarness {
+	t.Helper()
+	_, raw := dbtest.NewTestDB(t)
+	scoped := tenantstore.New(raw)
+
+	drivers := map[int64]storage.Driver{}
+	var mu sync.Mutex
+	resolver := func(id int64) (storage.Driver, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if d, ok := drivers[id]; ok {
+			return d, nil
+		}
+		st, err := raw.GetStorage(context.Background(), id)
+		if err != nil {
+			return nil, err
+		}
+		d, err := storage.Get(st.Driver)
+		if err != nil {
+			return nil, err
+		}
+		cfg := map[string]any{}
+		if err := json.Unmarshal(st.ConfigJSON, &cfg); err != nil {
+			return nil, err
+		}
+		if err := d.Init(context.Background(), cfg); err != nil {
+			return nil, err
+		}
+		drivers[id] = d
+		return d, nil
+	}
+
+	h := NewHandler(Config{
+		Enabled:     true,
+		Store:       scoped,
+		Resolver:    resolver,
+		ACL:         acl.New(raw),
+		MultiTenant: true,
+	})
+	mux := http.NewServeMux()
+	mux.Handle(Prefix+"/", h)
+	mux.Handle(Prefix, h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	inner := &harness{store: raw, h: h, srv: srv, resolver: resolver}
+	return &tenantHarness{harness: inner, raw: raw}
+}
+
+// addTenant creates a provider, an enabled storage linked to it, and an
+// admin-role user belonging to it — one olivov-style tenant.
+func (ha *tenantHarness) addTenant(t *testing.T, slug, storageName, email string, supertenant bool) (*model.Provider, *model.Storage, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Enabled matters: auth.LoginAllowed refuses a disabled provider, so a
+	// harness that forgets it gets 401 everywhere and every scoping
+	// assertion passes for the wrong reason.
+	p, err := ha.raw.CreateProvider(ctx, &model.Provider{
+		Slug: slug, Name: slug, AuthType: "local", IsSupertenant: supertenant, Enabled: true,
+	})
+	require.NoError(t, err)
+
+	st := ha.addStorage(t, storageName, false, false)
+	require.NoError(t, ha.raw.LinkProviderStorage(ctx, p.ID, st.ID))
+
+	password := "TenantPass!1"
+	hash, err := local.HashPassword(password)
+	require.NoError(t, err)
+	// role=admin on purpose: olivov's tenant admins hold filex role admin,
+	// which is what made this reachable.
+	u, err := ha.raw.CreateUser(ctx, email, hash, model.RoleAdmin, "en", "UTC")
+	require.NoError(t, err)
+	require.NoError(t, ha.raw.SetUserProvider(ctx, u.ID, p.ID, ""))
+
+	return p, st, password
+}
+
+// TestDAV_TenantScoping — a tenant admin (role=admin, provider not the
+// supertenant) must see and reach only their own provider's storages.
+//
+// Before the fix /dav resolved storages globally: olivov's diyetlif admin
+// mounted https://files.diyetlif.com.tr/dav/ in Finder and got all ten
+// tenants' storages listed, read-write, with DELETE hard-deleting rather
+// than going to trash (H4, 2026-08-05).
+func TestDAV_TenantScoping(t *testing.T) {
+	ha := newTenantHarness(t)
+	_, ownSt, pass := ha.addTenant(t, "diyetlif", "Dosyalar", "berk@diyetlif.test", false)
+	_, otherSt, _ := ha.addTenant(t, "arasboya", "ArasboyaDosyalar", "admin@arasboya.test", false)
+
+	const me = "berk@diyetlif.test"
+
+	t.Run("root lists only own storage", func(t *testing.T) {
+		resp := ha.req(t, "PROPFIND", "/dav/", me, pass, "", map[string]string{"Depth": "1"})
+		require.Equal(t, http.StatusMultiStatus, resp.StatusCode)
+		body := bodyString(t, resp)
+		require.Contains(t, body, ownSt.Name)
+		require.NotContains(t, body, otherSt.Name,
+			"another tenant's storage must not appear in the /dav root")
+	})
+
+	t.Run("foreign storage is not readable", func(t *testing.T) {
+		resp := ha.req(t, "PROPFIND", "/dav/"+otherSt.Name+"/", me, pass, "", map[string]string{"Depth": "1"})
+		require.Equal(t, http.StatusNotFound, resp.StatusCode,
+			"a path outside the caller's provider must 404, not enumerate")
+	})
+
+	t.Run("foreign storage is not writable", func(t *testing.T) {
+		resp := ha.req(t, http.MethodPut, "/dav/"+otherSt.Name+"/pwned.txt", me, pass, "x", nil)
+		require.NotEqual(t, http.StatusCreated, resp.StatusCode,
+			"writing into another tenant's storage must be refused")
+		require.GreaterOrEqual(t, resp.StatusCode, 400)
+	})
+
+	t.Run("foreign storage is not deletable", func(t *testing.T) {
+		resp := ha.req(t, http.MethodDelete, "/dav/"+otherSt.Name+"/", me, pass, "", nil)
+		require.GreaterOrEqual(t, resp.StatusCode, 400,
+			"DELETE on another tenant's storage is permanent — it must be refused")
+	})
+
+	t.Run("own storage still works", func(t *testing.T) {
+		resp := ha.req(t, http.MethodPut, "/dav/"+ownSt.Name+"/mine.txt", me, pass, "hello", nil)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+}
+
+// TestDAV_SupertenantSeesAll — "admin sees everything" stays true for an
+// admin of the supertenant provider, which is the platform operator.
+func TestDAV_SupertenantSeesAll(t *testing.T) {
+	ha := newTenantHarness(t)
+	_, opsSt, pass := ha.addTenant(t, "olivov", "OlivovDosyalar", "ops@olivov.test", true)
+	_, tenantSt, _ := ha.addTenant(t, "diyetlif", "Dosyalar", "berk@diyetlif.test", false)
+
+	resp := ha.req(t, "PROPFIND", "/dav/", "ops@olivov.test", pass, "", map[string]string{"Depth": "1"})
+	require.Equal(t, http.StatusMultiStatus, resp.StatusCode)
+	body := bodyString(t, resp)
+	require.Contains(t, body, opsSt.Name)
+	require.Contains(t, body, tenantSt.Name,
+		"the supertenant is confine-exempt and must still see every storage")
+}
+
+// TestDAV_UnresolvableProviderSeesNothing — multi-tenant mode fails closed:
+// an authenticated user whose provider_id doesn't resolve gets no storages
+// rather than falling through to "unscoped, see everything".
+//
+// provider_id is not FK-enforced, so a deleted or mis-migrated tenant leaves
+// exactly this dangling state.
+func TestDAV_UnresolvableProviderSeesNothing(t *testing.T) {
+	ha := newTenantHarness(t)
+	_, st, _ := ha.addTenant(t, "diyetlif", "Dosyalar", "berk@diyetlif.test", false)
+
+	ctx := context.Background()
+	password := "Orphan!1"
+	hash, err := local.HashPassword(password)
+	require.NoError(t, err)
+	u, err := ha.raw.CreateUser(ctx, "orphan@nowhere.test", hash, model.RoleAdmin, "en", "UTC")
+	require.NoError(t, err)
+	require.NoError(t, ha.raw.SetUserProvider(ctx, u.ID, 99999, ""))
+
+	resp := ha.req(t, "PROPFIND", "/dav/", "orphan@nowhere.test", password, "", map[string]string{"Depth": "1"})
+	require.Equal(t, http.StatusMultiStatus, resp.StatusCode)
+	require.False(t, strings.Contains(bodyString(t, resp), st.Name),
+		"a user whose provider doesn't resolve must see no storages")
+}
+
+// TestDAV_NewUsersLandInTheSupertenant documents a sharp edge this work
+// uncovered rather than a behaviour to rely on: store.CreateUser defaults
+// provider_id to 1, and provider 1 (`default`) is a SUPERTENANT. A user
+// created without an explicit provider is therefore confine-exempt and sees
+// every tenant's storages over /dav.
+//
+// That is what makes POST /api/admin/users ignoring provider_id a security
+// problem and not just an inconvenience (olivov G1).
+func TestDAV_NewUsersLandInTheSupertenant(t *testing.T) {
+	ha := newTenantHarness(t)
+	_, st, _ := ha.addTenant(t, "diyetlif", "Dosyalar", "berk@diyetlif.test", false)
+
+	ctx := context.Background()
+	password := "Fresh!1"
+	hash, err := local.HashPassword(password)
+	require.NoError(t, err)
+	u, err := ha.raw.CreateUser(ctx, "fresh@nowhere.test", hash, model.RoleAdmin, "en", "UTC")
+	require.NoError(t, err)
+	require.NotNil(t, u.ProviderID)
+
+	p, err := ha.raw.GetProvider(ctx, *u.ProviderID)
+	require.NoError(t, err)
+	require.True(t, p.IsSupertenant,
+		"a user created with no provider lands in the supertenant — see G1")
+
+	resp := ha.req(t, "PROPFIND", "/dav/", "fresh@nowhere.test", password, "", map[string]string{"Depth": "1"})
+	require.Equal(t, http.StatusMultiStatus, resp.StatusCode)
+	require.Contains(t, bodyString(t, resp), st.Name,
+		"...and consequently sees every tenant's storages")
+}

--- a/backend/internal/db/drivers/postgres/postgres.go
+++ b/backend/internal/db/drivers/postgres/postgres.go
@@ -781,7 +781,7 @@ func (s *Store) SearchNodes(ctx context.Context, storageID int64, like string, l
 const userCols = `id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, ` +
 	`COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,FALSE), ` +
 	`COALESCE(totp_recovery_codes_json::text,'[]'), locale, timezone, created_at, updated_at, last_login_at, ` +
-	`provider_id, COALESCE(oidc_subject,''), COALESCE(quota_bytes,0), COALESCE(usage_bytes,0)`
+	`provider_id, COALESCE(oidc_subject,''), COALESCE(quota_bytes,0), COALESCE(usage_bytes,0), COALESCE(enabled,TRUE)`
 
 func (s *Store) CreateUser(ctx context.Context, email, hash, role, locale, tz string) (*model.User, error) {
 	// New users default to the always-present "default" provider (the
@@ -1477,7 +1477,7 @@ func scanUser(r rowScanner) (*model.User, error) {
 	u := &model.User{}
 	var recoveryJSON string
 	var providerID sql.NullInt64
-	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &u.TOTPEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject, &u.QuotaBytes, &u.UsageBytes); err != nil {
+	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &u.TOTPEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject, &u.QuotaBytes, &u.UsageBytes, &u.Enabled); err != nil {
 		return nil, err
 	}
 	if recoveryJSON != "" {
@@ -2034,6 +2034,13 @@ func (s *Store) IncrementUserUsage(ctx context.Context, userID int64, delta int6
 }
 
 // SetUserQuota writes the quota_bytes value (0 = unlimited).
+// SetUserEnabled flips the account on/off. Files, quota and grants are
+// untouched -- this is an access switch, not a soft delete.
+func (s *Store) SetUserEnabled(ctx context.Context, userID int64, enabled bool) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE users SET enabled=$1 WHERE id=$2`, enabled, userID)
+	return err
+}
+
 func (s *Store) SetUserQuota(ctx context.Context, userID int64, bytes int64) error {
 	if bytes < 0 {
 		bytes = 0

--- a/backend/internal/db/drivers/postgres/postgres.go
+++ b/backend/internal/db/drivers/postgres/postgres.go
@@ -781,7 +781,7 @@ func (s *Store) SearchNodes(ctx context.Context, storageID int64, like string, l
 const userCols = `id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, ` +
 	`COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,FALSE), ` +
 	`COALESCE(totp_recovery_codes_json::text,'[]'), locale, timezone, created_at, updated_at, last_login_at, ` +
-	`provider_id, COALESCE(oidc_subject,'')`
+	`provider_id, COALESCE(oidc_subject,''), COALESCE(quota_bytes,0), COALESCE(usage_bytes,0)`
 
 func (s *Store) CreateUser(ctx context.Context, email, hash, role, locale, tz string) (*model.User, error) {
 	// New users default to the always-present "default" provider (the
@@ -1477,7 +1477,7 @@ func scanUser(r rowScanner) (*model.User, error) {
 	u := &model.User{}
 	var recoveryJSON string
 	var providerID sql.NullInt64
-	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &u.TOTPEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject); err != nil {
+	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &u.TOTPEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject, &u.QuotaBytes, &u.UsageBytes); err != nil {
 		return nil, err
 	}
 	if recoveryJSON != "" {

--- a/backend/internal/db/drivers/sqlite/sqlite.go
+++ b/backend/internal/db/drivers/sqlite/sqlite.go
@@ -1783,7 +1783,7 @@ func scanStorage(r rowScanner) (*model.Storage, error) {
 }
 
 func userSelect() string {
-	return `SELECT id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_recovery_codes_json,'[]'), locale, timezone, created_at, updated_at, last_login_at, provider_id, COALESCE(oidc_subject,'')`
+	return `SELECT id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_recovery_codes_json,'[]'), locale, timezone, created_at, updated_at, last_login_at, provider_id, COALESCE(oidc_subject,''), COALESCE(quota_bytes,0), COALESCE(usage_bytes,0)`
 }
 
 func scanUser(r rowScanner) (*model.User, error) {
@@ -1791,7 +1791,7 @@ func scanUser(r rowScanner) (*model.User, error) {
 	var totpEnabled int
 	var recoveryJSON string
 	var providerID sql.NullInt64
-	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &totpEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject); err != nil {
+	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &totpEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject, &u.QuotaBytes, &u.UsageBytes); err != nil {
 		return nil, err
 	}
 	u.TOTPEnabled = totpEnabled == 1

--- a/backend/internal/db/drivers/sqlite/sqlite.go
+++ b/backend/internal/db/drivers/sqlite/sqlite.go
@@ -1783,7 +1783,7 @@ func scanStorage(r rowScanner) (*model.Storage, error) {
 }
 
 func userSelect() string {
-	return `SELECT id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_recovery_codes_json,'[]'), locale, timezone, created_at, updated_at, last_login_at, provider_id, COALESCE(oidc_subject,''), COALESCE(quota_bytes,0), COALESCE(usage_bytes,0)`
+	return `SELECT id, email, COALESCE(display_name,''), COALESCE(password_hash,''), role, COALESCE(totp_secret,''), COALESCE(totp_pending_secret,''), COALESCE(totp_enabled,0), COALESCE(totp_recovery_codes_json,'[]'), locale, timezone, created_at, updated_at, last_login_at, provider_id, COALESCE(oidc_subject,''), COALESCE(quota_bytes,0), COALESCE(usage_bytes,0), COALESCE(enabled,1)`
 }
 
 func scanUser(r rowScanner) (*model.User, error) {
@@ -1791,10 +1791,12 @@ func scanUser(r rowScanner) (*model.User, error) {
 	var totpEnabled int
 	var recoveryJSON string
 	var providerID sql.NullInt64
-	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &totpEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject, &u.QuotaBytes, &u.UsageBytes); err != nil {
+	var enabled int
+	if err := r.Scan(&u.ID, &u.Email, &u.DisplayName, &u.PasswordHash, &u.Role, &u.TOTPSecret, &u.TOTPPendingSecret, &totpEnabled, &recoveryJSON, &u.Locale, &u.Timezone, &u.CreatedAt, &u.UpdatedAt, &u.LastLoginAt, &providerID, &u.OIDCSubject, &u.QuotaBytes, &u.UsageBytes, &enabled); err != nil {
 		return nil, err
 	}
 	u.TOTPEnabled = totpEnabled == 1
+	u.Enabled = enabled == 1
 	if recoveryJSON != "" {
 		_ = json.Unmarshal([]byte(recoveryJSON), &u.TOTPRecoveryCodes)
 	}
@@ -2132,6 +2134,17 @@ func (s *Store) IncrementUserUsage(ctx context.Context, userID int64, delta int6
 }
 
 // SetUserQuota sets the quota_bytes value for a user (0 = unlimited).
+// SetUserEnabled flips the account on/off. Files, quota and grants are
+// untouched -- this is an access switch, not a soft delete.
+func (s *Store) SetUserEnabled(ctx context.Context, userID int64, enabled bool) error {
+	v := 0
+	if enabled {
+		v = 1
+	}
+	_, err := s.db.ExecContext(ctx, `UPDATE users SET enabled=? WHERE id=?`, v, userID)
+	return err
+}
+
 func (s *Store) SetUserQuota(ctx context.Context, userID int64, bytes int64) error {
 	if bytes < 0 {
 		bytes = 0

--- a/backend/internal/db/store.go
+++ b/backend/internal/db/store.go
@@ -231,6 +231,9 @@ type Store interface {
 	GetUserUsage(ctx context.Context, userID int64) (used, limit int64, err error)
 	IncrementUserUsage(ctx context.Context, userID int64, delta int64) error
 	SetUserQuota(ctx context.Context, userID int64, bytes int64) error
+	// SetUserEnabled flips the account on/off (migration 00022). A disabled
+	// user cannot start a session; nothing they own is touched.
+	SetUserEnabled(ctx context.Context, userID int64, enabled bool) error
 	RecomputeUserUsage(ctx context.Context, userID int64) (int64, error)
 
 	// Node owner

--- a/backend/internal/db/user_provider_test.go
+++ b/backend/internal/db/user_provider_test.go
@@ -53,7 +53,7 @@ func TestUserProviderAndMaintenanceMode(t *testing.T) {
 	assert.False(t, auth.LoginAllowed(ctx, store, false, got))
 	// ...but mode-on allows it, and a nil-provider bootstrap admin is always ok.
 	assert.True(t, auth.LoginAllowed(ctx, store, true, got))
-	assert.True(t, auth.LoginAllowed(ctx, store, false, &model.User{}))
+	assert.True(t, auth.LoginAllowed(ctx, store, false, &model.User{Enabled: true}))
 
 	// SUSPEND: a disabled tenant's users cannot log in — in either mode.
 	p.Enabled = false

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -55,6 +55,10 @@ type User struct {
 	// /quota request per row.
 	QuotaBytes int64 `json:"quota_bytes"`
 	UsageBytes int64 `json:"used_bytes"`
+	// Enabled (migration 00022) gates whether the account may start a
+	// session — local login, OIDC and /dav alike. Disabling is not a soft
+	// delete: files, quota and grants are untouched.
+	Enabled bool `json:"enabled"`
 }
 
 // IsAdmin returns true if the user has the admin role.

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -50,6 +50,11 @@ type User struct {
 	// immutably at JIT login. OIDCSubject pins the OIDC identity per provider.
 	ProviderID  *int64 `json:"provider_id,omitempty"`
 	OIDCSubject string `json:"-"`
+	// Storage accounting (migration 00003). QuotaBytes == 0 means unlimited.
+	// Carried on the user so an admin table costs one call instead of one
+	// /quota request per row.
+	QuotaBytes int64 `json:"quota_bytes"`
+	UsageBytes int64 `json:"used_bytes"`
 }
 
 // IsAdmin returns true if the user has the admin role.

--- a/backend/internal/quota/service.go
+++ b/backend/internal/quota/service.go
@@ -8,6 +8,7 @@ package quota
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -16,6 +17,24 @@ import (
 
 // ErrQuotaExceeded is returned by CheckCanWrite when the user is out of room.
 var ErrQuotaExceeded = errors.New("quota: exceeded")
+
+// ErrUserNotFound means the id doesn't name a user.
+//
+// usage_bytes and quota_bytes are COALESCE'd columns on `users`, so a user
+// that exists always reads back (0, 0) = "unlimited, nothing used". A
+// no-rows result therefore says nothing about quotas — it says there is no
+// such user, and the caller should answer 404 rather than leak
+// `sql: no rows in result set` as a 500 (olivov H5, 2026-08-05).
+var ErrUserNotFound = errors.New("quota: user not found")
+
+// lookupUsage reads (used, limit) and normalises the missing-user case.
+func (s *Service) lookupUsage(ctx context.Context, userID int64) (int64, int64, error) {
+	used, limit, err := s.Store.GetUserUsage(ctx, userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, 0, ErrUserNotFound
+	}
+	return used, limit, err
+}
 
 // Service is the quota façade exposed to the rest of the codebase.
 type Service struct {
@@ -42,7 +61,12 @@ func (s *Service) CheckCanWrite(ctx context.Context, userID int64, addBytes int6
 	if userID <= 0 || addBytes <= 0 {
 		return nil
 	}
-	used, limit, err := s.Store.GetUserUsage(ctx, userID)
+	used, limit, err := s.lookupUsage(ctx, userID)
+	if errors.Is(err, ErrUserNotFound) {
+		// Anonymous/system writes already pass above; an id with no user
+		// row is not something to enforce a ceiling against.
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("quota: read usage: %w", err)
 	}
@@ -73,27 +97,38 @@ func (s *Service) SubUsage(ctx context.Context, userID int64, bytes int64) error
 }
 
 // Recompute rebuilds usage_bytes from the SUM(size) of nodes owned by the user.
+// Returns ErrUserNotFound for an id that isn't a user — the underlying UPDATE
+// would otherwise touch no rows and report success.
 func (s *Service) Recompute(ctx context.Context, userID int64) (int64, error) {
 	if s == nil || s.Store == nil || userID <= 0 {
 		return 0, nil
+	}
+	if _, _, err := s.lookupUsage(ctx, userID); err != nil {
+		return 0, err
 	}
 	return s.Store.RecomputeUserUsage(ctx, userID)
 }
 
 // SetQuota writes a new quota_bytes value (admin only — caller enforces).
+// Returns ErrUserNotFound for an id that isn't a user, so an admin doesn't
+// get a 200 for a write that landed nowhere.
 func (s *Service) SetQuota(ctx context.Context, userID int64, bytes int64) error {
 	if s == nil || s.Store == nil {
 		return nil
 	}
+	if _, _, err := s.lookupUsage(ctx, userID); err != nil {
+		return err
+	}
 	return s.Store.SetUserQuota(ctx, userID, bytes)
 }
 
-// Get returns the current snapshot.
+// Get returns the current snapshot. Returns ErrUserNotFound for an id that
+// isn't a user.
 func (s *Service) Get(ctx context.Context, userID int64) (Snapshot, error) {
 	if s == nil || s.Store == nil {
 		return Snapshot{Unlimited: true}, nil
 	}
-	used, limit, err := s.Store.GetUserUsage(ctx, userID)
+	used, limit, err := s.lookupUsage(ctx, userID)
 	if err != nil {
 		return Snapshot{}, err
 	}

--- a/backend/internal/storage/drivers/s3/s3.go
+++ b/backend/internal/storage/drivers/s3/s3.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -267,13 +268,64 @@ func (d *Driver) Read(ctx context.Context, p string) (io.ReadCloser, error) {
 }
 
 // Write implements storage.Writer.
+//
+// The body MUST go out with a Content-Length. When the SDK can't measure it
+// — a plain io.Reader with no Seeker, which is what the upload handler
+// produces after mime-sniffing — it falls back to Transfer-Encoding:
+// chunked. AWS and MinIO accept that, but the S3 spec leaves it to the
+// provider, and DT Cloud S3 answers `411 MissingContentLength`, which broke
+// every browser upload while WebDAV and MCP (both of which hand over a
+// seekable body) kept working. So: declare the length we were given, and
+// when the caller genuinely doesn't know it, measure the body first.
 func (d *Driver) Write(ctx context.Context, p string, r io.Reader, size int64) error {
-	_, err := d.client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(d.bucket),
-		Key:    aws.String(d.key(p)),
-		Body:   r,
+	body, size, release, err := measuredBody(r, size)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	_, err = d.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(d.bucket),
+		Key:           aws.String(d.key(p)),
+		Body:          body,
+		ContentLength: aws.Int64(size),
 	})
 	return err
+}
+
+// measuredBody returns a reader whose length is known, so PutObject can send
+// a Content-Length instead of a chunked body.
+//
+// A caller that already knows the size gets its reader back untouched — the
+// common path, no copying. A caller passing size < 0 ("I don't know") gets
+// the body spooled to a temp file so the length can be measured; this mirrors
+// what the WebDAV surface already does on its own before calling in.
+func measuredBody(r io.Reader, size int64) (io.Reader, int64, func(), error) {
+	noop := func() {}
+	if size >= 0 {
+		return r, size, noop, nil
+	}
+
+	tmp, err := os.CreateTemp("", "filex-s3-put-*")
+	if err != nil {
+		return nil, 0, noop, fmt.Errorf("s3: spool: %w", err)
+	}
+	release := func() {
+		name := tmp.Name()
+		_ = tmp.Close()
+		_ = os.Remove(name)
+	}
+
+	n, err := io.Copy(tmp, r)
+	if err != nil {
+		release()
+		return nil, 0, noop, fmt.Errorf("s3: spool: %w", err)
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		release()
+		return nil, 0, noop, fmt.Errorf("s3: spool rewind: %w", err)
+	}
+	return tmp, n, release, nil
 }
 
 // emptyMarker is the hidden 0-byte object filex writes inside a folder so an

--- a/backend/internal/storage/drivers/s3/s3.go
+++ b/backend/internal/storage/drivers/s3/s3.go
@@ -209,6 +209,20 @@ func (d *Driver) Stat(ctx context.Context, p string) (storage.Object, error) {
 	})
 	if err != nil {
 		if isS3NotFound(err) {
+			// S3 has no directories. A folder is a prefix — for an empty one,
+			// a prefix carrying nothing but the hidden .empty marker — so
+			// there is no object at the bare key to HeadObject. Falling
+			// straight through to ErrNotFound made every folder look missing:
+			// WebDAV stats the parent before a PUT and maps a miss to 409, so
+			// olivov could write to a storage root but into no subfolder, and
+			// PROPFIND on a folder 404'd (H3, 2026-08-05).
+			if d.hasChildren(ctx, p) {
+				return storage.Object{
+					Path: p,
+					Name: path.Base(p),
+					Kind: storage.KindDirectory,
+				}, nil
+			}
 			return storage.Object{}, storage.ErrNotFound
 		}
 		return storage.Object{}, fmt.Errorf("s3: head: %w", err)
@@ -456,9 +470,17 @@ func (d *Driver) copyDir(ctx context.Context, src, dst string, del bool) error {
 // isDir reports whether p is a directory: no object exists at the exact key but
 // ≥1 object exists under the p/ prefix. A real object at the key ⇒ file.
 func (d *Driver) isDir(ctx context.Context, p string) bool {
-	if _, err := d.Stat(ctx, p); err == nil {
+	obj, err := d.Stat(ctx, p)
+	if err != nil {
 		return false
 	}
+	return obj.Kind == storage.KindDirectory
+}
+
+// hasChildren reports whether any object lives under p's prefix. This is the
+// only thing that makes a folder "exist" on an object store. Kept separate
+// from isDir so Stat can use it without the two recursing into each other.
+func (d *Driver) hasChildren(ctx context.Context, p string) bool {
 	keys, _ := d.listKeysUnder(ctx, p)
 	return len(keys) > 0
 }

--- a/backend/internal/storage/drivers/s3/s3_stat_test.go
+++ b/backend/internal/storage/drivers/s3/s3_stat_test.go
@@ -1,0 +1,123 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brf-tech/filex/backend/internal/storage"
+)
+
+// listXML renders a minimal ListObjectsV2 response holding the given keys.
+func listXML(prefix string, keys ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, `<?xml version="1.0" encoding="UTF-8"?>`+
+		`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`+
+		`<Name>b</Name><Prefix>%s</Prefix><KeyCount>%d</KeyCount>`+
+		`<MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated>`, prefix, len(keys))
+	for _, k := range keys {
+		fmt.Fprintf(&b, `<Contents><Key>%s</Key>`+
+			`<LastModified>2026-08-05T00:00:00.000Z</LastModified>`+
+			`<ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>`+
+			`<Size>0</Size><StorageClass>STANDARD</StorageClass></Contents>`, k)
+	}
+	b.WriteString(`</ListBucketResult>`)
+	return b.String()
+}
+
+// objectStoreStub answers HeadObject 404 for every key (nothing is a real
+// object) and ListObjectsV2 with whatever `contents` holds for the requested
+// prefix — an object store where "deneme/" exists only as a prefix carrying
+// a .empty marker, which is exactly how filex represents an empty folder.
+func statStub(t *testing.T, contents map[string][]string) *Driver {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("list-type") == "2" {
+			prefix := r.URL.Query().Get("prefix")
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(listXML(prefix, contents[prefix]...)))
+			return
+		}
+		http.Error(w, "", http.StatusNotFound) // HeadObject / GetObject
+	}))
+	t.Cleanup(srv.Close)
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("auto"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("fake", "fake", ""),
+		),
+	)
+	require.NoError(t, err)
+
+	d := &Driver{bucket: "b", region: "auto", endpoint: srv.URL, pathStyle: true}
+	d.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(srv.URL)
+		o.UsePathStyle = true
+		o.HTTPClient = srv.Client()
+	})
+	return d
+}
+
+// TestStat_FolderIsADirectory — Stat used to HeadObject the bare key and
+// stop there. S3 has no directories: a folder is a prefix, and filex marks
+// an empty one with a hidden .empty object *inside* it. So Stat answered
+// ErrNotFound for every folder.
+//
+// WebDAV is where that surfaced: OpenFile stats the parent before a PUT and
+// maps a miss to 409, and PROPFIND on the folder 404'd. olivov could write
+// to a storage root but not into any subfolder (H3, 2026-08-05).
+func TestStat_FolderIsADirectory(t *testing.T) {
+	d := statStub(t, map[string][]string{
+		"deneme/": {"deneme/.empty"},
+	})
+
+	obj, err := d.Stat(context.Background(), "/deneme")
+	require.NoError(t, err, "a prefix with contents must stat as a directory")
+	assert.Equal(t, storage.KindDirectory, obj.Kind)
+	assert.Equal(t, "deneme", obj.Name)
+	assert.Equal(t, "/deneme", obj.Path)
+}
+
+// TestStat_FolderWithRealFiles — a folder holding actual files, not just the
+// marker.
+func TestStat_FolderWithRealFiles(t *testing.T) {
+	d := statStub(t, map[string][]string{
+		"projeler/": {"projeler/a.txt", "projeler/b.txt"},
+	})
+
+	obj, err := d.Stat(context.Background(), "projeler")
+	require.NoError(t, err)
+	assert.Equal(t, storage.KindDirectory, obj.Kind)
+}
+
+// TestStat_MissingIsStillNotFound — an empty prefix is not a directory, and
+// the not-found mapping must survive the fix so callers keep getting clean
+// 404s instead of a phantom folder.
+func TestStat_MissingIsStillNotFound(t *testing.T) {
+	d := statStub(t, map[string][]string{})
+
+	_, err := d.Stat(context.Background(), "/yok")
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// TestIsDir_StillWorks — isDir shares the prefix probe with Stat; guard
+// against the two recursing into each other.
+func TestIsDir_StillWorks(t *testing.T) {
+	d := statStub(t, map[string][]string{
+		"deneme/": {"deneme/.empty"},
+	})
+
+	assert.True(t, d.isDir(context.Background(), "/deneme"))
+	assert.False(t, d.isDir(context.Background(), "/yok"))
+}

--- a/backend/internal/storage/drivers/s3/s3_write_test.go
+++ b/backend/internal/storage/drivers/s3/s3_write_test.go
@@ -1,0 +1,126 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedPut records what the fake object store actually received on the
+// wire for a PutObject.
+type capturedPut struct {
+	contentLength    int64
+	transferEncoding []string
+	body             []byte
+}
+
+// fakeS3 stands up an httptest server that answers every PutObject with 200
+// and records the framing of the request. A real S3 endpoint that refuses
+// chunked bodies (DT Cloud S3) answers 411 instead; asserting on
+// Content-Length here is the same check without the network.
+//
+// The server speaks TLS on purpose. Over plain HTTP the SDK signs the
+// payload and needs to rewind the body, which fails for a different reason
+// than the one we're testing; over HTTPS it uses UNSIGNED-PAYLOAD, exactly
+// like the production DT Cloud S3 endpoint, so what's left under test is
+// the request framing.
+func fakeS3(t *testing.T, got *capturedPut) *Driver {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		got.contentLength = r.ContentLength
+		got.transferEncoding = r.TransferEncoding
+		got.body = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("auto"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("fake", "fake", ""),
+		),
+	)
+	require.NoError(t, err)
+
+	d := &Driver{bucket: "b", region: "auto", endpoint: srv.URL, pathStyle: true}
+	d.client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(srv.URL)
+		o.UsePathStyle = true
+		o.HTTPClient = srv.Client() // trusts the httptest cert
+	})
+	return d
+}
+
+// nonSeekable wraps a reader so it exposes ONLY io.Reader — no Seeker, no
+// Len(). This is what the upload handler hands the driver: it sniffs the
+// first 512 bytes for mime detection and rejoins them with
+// io.MultiReader(bytes.NewReader(sniff), part), which the AWS SDK cannot
+// measure on its own.
+type nonSeekable struct{ r io.Reader }
+
+func (n nonSeekable) Read(p []byte) (int, error) { return n.r.Read(p) }
+
+// TestWrite_SendsContentLength — a non-seekable body must still go out with
+// a Content-Length header. Without it the SDK falls back to
+// Transfer-Encoding: chunked; AWS and MinIO accept that, but the S3 spec
+// lets a provider answer 411 MissingContentLength and DT Cloud S3 does,
+// which broke every browser upload (olivov H1, 2026-08-05).
+func TestWrite_SendsContentLength(t *testing.T) {
+	var got capturedPut
+	d := fakeS3(t, &got)
+
+	payload := []byte("hello olivov")
+	body := nonSeekable{io.MultiReader(
+		bytes.NewReader(payload[:5]),
+		bytes.NewReader(payload[5:]),
+	)}
+
+	require.NoError(t, d.Write(context.Background(), "/x.txt", body, int64(len(payload))))
+
+	assert.Equal(t, int64(len(payload)), got.contentLength,
+		"PutObject must declare Content-Length for a non-seekable body")
+	assert.Empty(t, got.transferEncoding,
+		"body must not be sent chunked")
+	assert.Equal(t, payload, got.body)
+}
+
+// TestWrite_SeekableStillWorks guards the path that already worked (MCP
+// file_write, WebDAV spool, the .empty marker) so the fix doesn't regress
+// it.
+func TestWrite_SeekableStillWorks(t *testing.T) {
+	var got capturedPut
+	d := fakeS3(t, &got)
+
+	require.NoError(t, d.Write(context.Background(), "/y.txt", strings.NewReader("abc"), 3))
+
+	assert.Equal(t, int64(3), got.contentLength)
+	assert.Empty(t, got.transferEncoding)
+	assert.Equal(t, []byte("abc"), got.body)
+}
+
+// TestWrite_UnknownSizeBuffers — callers that genuinely don't know the
+// length (size < 0) must still produce a measured request rather than a
+// chunked one, since the provider would reject it.
+func TestWrite_UnknownSizeBuffers(t *testing.T) {
+	var got capturedPut
+	d := fakeS3(t, &got)
+
+	body := nonSeekable{strings.NewReader("unknown length")}
+	require.NoError(t, d.Write(context.Background(), "/z.txt", body, -1))
+
+	assert.Equal(t, int64(len("unknown length")), got.contentLength)
+	assert.Empty(t, got.transferEncoding)
+	assert.Equal(t, []byte("unknown length"), got.body)
+}

--- a/backend/internal/testutil/testutil.go
+++ b/backend/internal/testutil/testutil.go
@@ -29,6 +29,7 @@ import (
 	"github.com/brf-tech/filex/backend/internal/config"
 	"github.com/brf-tech/filex/backend/internal/db"
 	"github.com/brf-tech/filex/backend/internal/model"
+	"github.com/brf-tech/filex/backend/internal/quota"
 	"github.com/brf-tech/filex/backend/internal/share"
 	"github.com/brf-tech/filex/backend/internal/storage"
 	syncpkg "github.com/brf-tech/filex/backend/internal/sync"
@@ -173,8 +174,13 @@ func NewTestServerWith(t *testing.T, cfgMutate func(*config.Config), depsMutate 
 	}
 
 	deps := &api.Deps{
-		Cfg:             cfg,
-		Store:           store,
+		Cfg:   cfg,
+		Store: store,
+		// Quota is wired by default: with it nil the service short-circuits
+		// to "unlimited, no error", so the whole /api/admin/quota surface
+		// answered 200 in tests no matter what the DB said and the H5
+		// no-rows-is-a-500 bug was invisible here.
+		Quota:           quota.New(store),
 		Worker:          worker,
 		Caps:            caps,
 		Share:           share.NewService(store),

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -429,26 +429,108 @@ Validates the connection without persisting.
 ## Admin: users
 
 ### `GET /api/admin/users` ![admin](https://img.shields.io/badge/-admin-red)
-List users. `?q=…` for search, `?role=admin|user` filter.
+List users. In multi-tenant mode the list is confined to the caller's tenant
+(the supertenant sees all). Each row carries `used_bytes` and `quota_bytes`
+(`0` = unlimited) and `enabled`, so a usage table costs one call.
+
+### `GET /api/admin/users/{id}` ![admin](https://img.shields.io/badge/-admin-red)
 
 ### `POST /api/admin/users` ![admin](https://img.shields.io/badge/-admin-red)
 ```json
 {
   "email": "newuser@example.com",
-  "username": "newuser",
+  "display_name": "New User",
   "role": "user",
-  "password": "..."
+  "password": "...",
+  "provider_id": 3
 }
 ```
-For OIDC users, omit password.
+`provider_id` homes the user in a tenant. Omit it and the user lands in the
+**caller's** tenant. A tenant admin may only name their own provider (`403`
+otherwise); an id that matches no provider is `400`. There is no foreign key
+behind the column, so it is validated here.
 
-### `PUT /api/admin/users/:id` ![admin](https://img.shields.io/badge/-admin-red)
-Partial update (role, disabled, password reset).
+### `PATCH /api/admin/users/{id}` ![admin](https://img.shields.io/badge/-admin-red)
+Partial update — only the fields present in the body are touched:
+`password`, `display_name`, `role`, `locale`, `timezone`, `enabled`,
+`provider_id`.
 
-### `DELETE /api/admin/users/:id` ![admin](https://img.shields.io/badge/-admin-red)
+`enabled: false` cuts access without deleting anything: the account cannot
+log in (local, OIDC or `/dav`), existing sessions stop working, and every API
+token it minted is refused. Files, quota and grants are untouched. Disabling
+— like deleting or demoting — the **last admin** is refused with `409`.
 
-### `POST /api/admin/users/:id/disable` ![admin](https://img.shields.io/badge/-admin-red)
-### `POST /api/admin/users/:id/enable` ![admin](https://img.shields.io/badge/-admin-red)
+`provider_id` re-homes the user into another tenant. Restricted to an
+unscoped or supertenant caller (`403` otherwise).
+
+### `GET|POST|PATCH /api/admin/users/{id}/quota` ![admin](https://img.shields.io/badge/-admin-red)
+Read or set one user's quota — see [Admin: quota](#admin-quota). `POST
+/api/admin/users/{id}/quota/recompute` rebuilds `used_bytes` from node sizes.
+
+### `DELETE /api/admin/users/{id}` ![admin](https://img.shields.io/badge/-admin-red)
+Deletes the account row. The last remaining admin cannot be deleted (`409`),
+not even by itself.
+
+**What happens to their files: nothing.** No storage object is ever removed.
+The node rows survive and `nodes.owner_id` becomes `NULL`, so the files
+become **unowned** — still present, still listed, still reachable by anyone
+whose access does not depend on that user. Deletion is not a way to reclaim
+space; move or delete the files first if that is the intent.
+
+Precisely, on `DELETE`:
+
+| Kept, with the user dropped (`SET NULL`) | Removed with the user (`CASCADE`) |
+| --- | --- |
+| `nodes.owner_id` — the files themselves | `sessions` |
+| `shares.created_by` — see below | `api_tokens` |
+| `file_grants.created_by` | `file_grants.user_id` — access granted **to** them |
+| `audit_log.user_id` — history stays readable | `notifications`, `user_node_meta`, `node_comments` |
+
+Share links the user created **stay live**: public resolution never looks at
+`created_by`. But revoking one does, and a `NULL` creator matches nobody — so
+an orphaned link can only be revoked by an admin, via
+`DELETE /api/admin/shares/{id}`. Audit those before deleting a user who
+shared a lot.
+
+Their `usage_bytes` row goes with the account, so those bytes stop counting
+toward any per-user total while the files remain on storage. To keep the
+account's history and quota intact, prefer `enabled: false` over deletion.
+
+---
+
+## Admin: quota
+
+Quota is **per user**. There is no per-provider (tenant) quota — see
+[MULTI-TENANCY.md](MULTI-TENANCY.md). Every id in this section is a **user
+id**; passing a provider id answers `404`.
+
+Two spellings, same handlers:
+
+| Nested (preferred) | Flat (original) |
+| --- | --- |
+| `GET /api/admin/users/{id}/quota` | `GET /api/admin/quota/{user_id}` |
+| `POST` / `PATCH /api/admin/users/{id}/quota` | `POST /api/admin/quota/{user_id}` |
+| `POST /api/admin/users/{id}/quota/recompute` | `POST /api/admin/quota/{user_id}/recompute` |
+
+### `GET …/quota` ![admin](https://img.shields.io/badge/-admin-red)
+```json
+{ "used_bytes": 1234, "quota_bytes": 5368709120, "percent_used": 0.00002, "unlimited": false }
+```
+A user who has never had a quota set reads back `quota_bytes: 0`,
+`unlimited: true` — that is not an error. An id that names no user is `404`.
+
+### `POST|PATCH …/quota` ![admin](https://img.shields.io/badge/-admin-red)
+```json
+{ "quota_bytes": 5368709120 }
+```
+`0` means unlimited; negative is `400`. Returns the fresh snapshot.
+
+### `POST …/quota/recompute` ![admin](https://img.shields.io/badge/-admin-red)
+Rebuilds `used_bytes` from the summed size of the nodes the user owns.
+Worth running after bulk imports, or after deleting a user whose files were
+left behind (their bytes stop being attributed to anyone).
+
+The caller's own snapshot is at `GET /api/files/quota/me`.
 
 ---
 

--- a/docs/WEBDAV.md
+++ b/docs/WEBDAV.md
@@ -158,6 +158,14 @@ WebDAV enforces exactly the same authorization model as the web UI:
 - Changes made over WebDAV are indexed **best-effort right away** (node
   cache, search, thumbnails); if anything hiccups, the storage's scheduled
   sync run reconciles later.
-- Multi-tenant installs: `/dav` currently resolves storages **globally by
-  name** (host-based tenant scoping does not apply to this surface yet).
+- Multi-tenant installs: `/dav` is **tenant-scoped**. The scope comes from the
+  authenticated user's provider — not the request Host — so it matches what
+  the JSON API and the web UI apply. A caller sees only their own provider's
+  storages in the root, and any path under another provider's storage answers
+  `404` (a foreign storage is indistinguishable from one that isn't there).
+  Admins of the **supertenant** provider stay confine-exempt and see
+  everything; `role: admin` on a regular tenant means admin *of that tenant*.
   Suspended-tenant users are refused at login.
+
+  Before this, `/dav` resolved storages globally by name, so any tenant admin
+  could list, read, write and permanently delete every other tenant's files.

--- a/packages/core/src/FileExplorer.vue
+++ b/packages/core/src/FileExplorer.vue
@@ -1921,9 +1921,16 @@ async function legacyUpload(file: File) {
     patch({ percent: 100, uploadedBytes: file.size, status: 'done' });
     emit('upload-progress', { uploadId: id, percent: 100, done: true });
   } catch (err) {
-    patch({ status: 'error' });
+    // Tell the USER, not just the embedding app. `emit('error')` alone left a
+    // standalone deployment silent: the progress bar ran to 100% (the bytes
+    // do go out — the server rejects them afterwards), the row flipped to an
+    // error state carrying no message, and nothing else appeared. olivov lost
+    // ten days of uploads to that silence (H2, 2026-08-05).
+    const message = (err as Error).message;
+    patch({ status: 'error', error: message });
+    flashToast(t('upload.failed', { name: file.name }));
     emit('error', {
-      message: (err as Error).message,
+      message,
       context: { op: 'upload', file: file.name },
     });
   }
@@ -2390,6 +2397,7 @@ function retryUploadJob(job: UploadJob) {
     })
     .catch((err: Error) => {
       patchRetry({ status: 'error', error: err.message });
+      flashToast(t('upload.failed', { name: file.name }));
       emit('error', { message: err.message, context: { op: 'upload-retry', file: file.name } });
     });
 }

--- a/packages/core/src/locales/en.ts
+++ b/packages/core/src/locales/en.ts
@@ -54,6 +54,7 @@ export const en: Record<string, string> = {
   'upload.progress': 'Uploading',
   'upload.done': 'Done',
   'upload.error': 'Error',
+  'upload.failed': 'Could not upload “{name}”',
   'upload.aborted': 'Aborted',
   'upload.cancel': 'Cancel',
 

--- a/packages/core/src/locales/tr.ts
+++ b/packages/core/src/locales/tr.ts
@@ -54,6 +54,7 @@ export const tr: Record<string, string> = {
   'upload.progress': 'Yükleniyor',
   'upload.done': 'Tamamlandı',
   'upload.error': 'Hata',
+  'upload.failed': '“{name}” yüklenemedi',
   'upload.aborted': 'İptal edildi',
   'upload.cancel': 'İptal',
 


### PR DESCRIPTION
Closes the ten open items olivov filed against v0.8.0 (multi-tenant, 10
providers, DT Cloud S3). Each commit is one item with a failing test first.

## Bugs

| | | |
|---|---|---|
| **H1** | Browser uploads all failed | `s3.Write` took a `size` argument and dropped it. With a non-seekable body the SDK framed the request chunked with no `Content-Length`; AWS and MinIO accept that, DT Cloud S3 answers `411`. WebDAV, MCP and the `.empty` marker kept working because all three hand the driver a seekable body. Also rewinds the multipart part after mime-sniffing instead of wrapping it in `io.MultiReader`, which is what made it opaque. |
| **H2** | Failures were silent | `legacyUpload` set the job to `error` without the message and reported the rest through `emit('error')` — an event a standalone deployment has nothing listening for. The progress bar still ran to 100%, because the bytes really are sent. Ten days of broken uploads went unnoticed. |
| **H4** | **Cross-tenant read/write/delete over `/dav`** | Two holes. `/dav` does its own Basic auth so it is mounted outside the chain that runs `TenantResolver` — no scope reached the scoped store. And `storageByName` resolves through `GetStorageByName`, which `tenantstore` does not wrap. Any tenant admin reached every tenant's storages, and DELETE over WebDAV is permanent. Foreign storages now answer 404, preserving the no-exists-oracle rule; supertenant admins stay confine-exempt. |
| **H3** | WebDAV subfolders 409/404 | Not a WebDAV bug: `s3.Stat` only did `HeadObject`, and on S3 a folder is a prefix. Every folder looked missing, so the pre-PUT parent stat failed. `List` already resolved directories via CommonPrefixes; `Stat` now does too, and `isDir` is rebuilt on top of it. |
| **H5** | `GET /api/admin/quota/{id}` → 500 | `usage_bytes`/`quota_bytes` are COALESCE'd columns on `users`, so no-rows can only mean "no such user" — a 404. Set and recompute were worse: both ran an UPDATE matching nothing and answered 200. |
| **H6** | Unqualified permission path | Fell back to `storages[0]` and wrote the grant there. Elsewhere that fallback is fine because a wrong guess shows up in the next listing; a grant is durable authorization state written where nobody looks again. Now 400, plus the tenant gate on the same unconfined lookup. |

## Features

**G1** — `POST /api/admin/users` dropped `provider_id`, so users fell to `CreateUser`'s default of provider 1. Provider 1 is `default`, and `default` is the **supertenant**: accounts meant for one tenant came out confine-exempt. Absent, the user now lands in the caller's tenant; a tenant admin naming another gets 403; an unknown id gets 400 (no FK behind the column). `PATCH` can re-home a user — supertenant only, and the repair path for accounts already stranded.

**G2/G3** — per-user quota was already implemented, but `handlers/quota.go` documented it at `/api/admin/users/{id}/quota`, a path that did not exist. Reading the doc, getting 404, and concluding it was unimplemented is exactly what happened. Both spellings are served now, and `used_bytes`/`quota_bytes` ride on the user object so a table is one call.

**G4** — `users.enabled` (migration 00022, defaults true). Refusing the next login is not enough: a session cookie minted before the switch and every API token the user ever created both outlive it. All three paths now refuse a disabled account. Disabling the last admin is 409.

## Notes for review

- `testutil.NewTestServer` never wired `Deps.Quota`. With it nil the service short-circuits to "unlimited, no error", so every quota assertion in the suite passed regardless of the DB. That is why none of H5 was caught here.
- `Enabled bool` has a zero-value trap: a `model.User` built in Go rather than read from the DB reads as disabled. That direction is the safe one and every production construction site is accounted for, but it is worth knowing.
- **Out of scope, still open:** only the LIST endpoint under `/api/admin/users` is tenant-confined. `Get`, `Update` and `Delete` act on any id, so a tenant admin can read, modify and delete another tenant's users by id. Same class as the `/dav` leak.

`go test ./...` is clean; `cmd/filex` and `embed` fail before and after (they need built frontend assets). `packages/core` typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
