### PR TITLE
feat(ui): open the storage directly when only one is visible

### DIFF
--- a/packages/core/src/FileExplorer.vue
+++ b/packages/core/src/FileExplorer.vue
@@ -274,12 +274,26 @@ const trashMode = ref(false);
 const trashOrigin = ref<string>('');
 const trashActive = computed(() => trashMode.value);
 
+// When the caller can see exactly ONE storage, the multi-storage root is a
+// one-row list that carries no information — the user clicks through it every
+// single time. Treat that storage as the floor instead: open it directly and
+// stop offering an "up" that only leads back to the one row.
+//
+// Empty string means "not in that situation" (single-storage mode, or more
+// than one storage visible), which leaves every existing path untouched.
+const soleStorageName = computed(() => {
+  if (!multiStorageRoot.value) return '';
+  const list = props.config.storages ?? [];
+  return list.length === 1 ? list[0].name : '';
+});
+
 // canGoUp/goUp — toolbar's "↑ Up one level" button. In single-storage
 // mode "" means the storage root; in multi-storage mode "" means
 // the global root (storage list). Both → no parent → button hidden.
 const canGoUp = computed(() => {
   const p = (currentPath.value ?? '').replace(/^\/+|\/+$/g, '');
   if (rootFloor && p === rootFloor) return false; // at the confined floor — nowhere above
+  if (soleStorageName.value && p === soleStorageName.value) return false;
   return p.length > 0;
 });
 
@@ -300,6 +314,8 @@ function goUp() {
   }
   const cur = (currentPath.value ?? '').replace(/^\/+|\/+$/g, '');
   if (!cur || cur === rootFloor) return;
+  // The button is hidden here, but Alt+↑ / Backspace still route through.
+  if (soleStorageName.value && cur === soleStorageName.value) return;
   const idx = cur.lastIndexOf('/');
   let parent = idx === -1 ? '' : cur.slice(0, idx);
   // Never step above the confined floor.
@@ -694,6 +710,10 @@ async function load(path?: string) {
     // Multi-storage virtual root — synthesize a list of storages
     // instead of calling the backend.
     if (multiStorageRoot.value && !virtualToWire(requested)) {
+      // One visible storage → skip the one-row list and open it. Recursion is
+      // bounded: the recursive call carries a non-empty path, so
+      // virtualToWire() resolves and this branch is not re-entered.
+      if (soleStorageName.value) return await load(soleStorageName.value);
       currentPath.value = '';
       adapter.value = '';
       dirname.value = '';


### PR DESCRIPTION
In multi-storage mode the explorer always renders the storage list as its root.
When the caller can see exactly one storage, that root is a **one-row list**
carrying no information — every visit starts by clicking through it.

Worse, it reads as a folder the user can't delete, rename or upload into,
because it isn't a folder: it's the mount. That's the question olivov asked —
"there's a Dosyalar folder at the top and I can't delete it, why?" — and the
honest answer is that the UI is presenting a mount as a directory for no gain.

This is the *normal* shape of a multi-tenant install, not an edge case: olivov
runs ten providers, each with exactly one storage, so every user pays that
click on every visit.

## Change

With exactly one visible storage, the explorer treats it as the floor:

- `load()` opens it instead of listing it.
- "Up" is no longer offered there — the only place above is the row you just
  came from.

Both up routes are covered. The toolbar button hides via `canGoUp`, but
`Alt+↑` / `Backspace` still dispatch through `goUp()`, and without the second
guard the two fight each other: up → one-row root → auto-enter → up → …

Recursion is bounded: the recursive `load()` carries a non-empty path, so
`virtualToWire()` resolves and the virtual-root branch isn't re-entered.

`soleStorageName` is `''` for single-storage mode and for anyone seeing two or
more storages, so both of those run exactly as before. The split pane never
rendered the storage-list root, so it needs no change.

Side effect, and the point of it: New Folder / Upload / Paste and the trash row
are available immediately instead of one level in, because `atVirtualRoot` is
never true for these users any more.

`vue-tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
