### PR TITLE
desktop: pairing survives signed-in browsers; host-arch CLI; macOS packages (ad-hoc sealed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,9 +147,16 @@ jobs:
   # a tag with no release yet fails: v0.20.1 duly produced a 125 MB AppImage
   # and an 87 MB .deb, then attached neither.
   #
-  # ⚠ Windows and Linux only. An unsigned macOS build is refused by Gatekeeper
-  # with a message that reads like corruption, so shipping one would be worse
-  # than shipping none; mac needs a Developer ID certificate first.
+  # ⚠ macOS ships UNSIGNED but ad-hoc SEALED (desktop/scripts/adhoc-sign.cjs).
+  # The distinction is what dialog the user gets: a linker-signed-only bundle
+  # (what electron-builder emits with no certificate) is treated as TAMPERED —
+  # macOS 26 says "malware blocked and moved to Trash", no override offered
+  # (measured 2026-08-18). A deep ad-hoc re-seal turns that into the honest
+  # "unverified developer" dialog with the System Settings → Open Anyway path.
+  # Still second-best: a Developer ID certificate + notarization removes the
+  # dialog entirely, and mac AUTO-update stays inert until then (Squirrel.Mac
+  # refuses to swap an unsigned app). arm64 only — macOS 26 deprecates Rosetta,
+  # and the fleet this ships to is Apple Silicon.
   #
   # ⚠ The artefacts are attached to the GitHub Release, which is NOT the
   # auto-update feed: this repository is private, and pointing electron-updater
@@ -169,6 +176,13 @@ jobs:
           - os: ubuntu-latest
             label: linux
             script: "dist:linux"
+          # Pinned rather than macos-latest: the runner's arch IS the
+          # artifact's arch (electron-builder defaults to the host, and
+          # fetch-cli.mjs compiles the embedded CLI for the host), so a silent
+          # image bump must not silently change what users download.
+          - os: macos-14
+            label: macos
+            script: "dist:mac"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -204,6 +218,12 @@ jobs:
           npm version "$VER" --no-git-tag-version --allow-same-version
           node -e "console.log('desktop version =', require('./package.json').version)"
       - name: Build installer
+        env:
+          # Never let the mac runner auction its keychain: a stray self-signed
+          # certificate would produce a "signed" build that fails Gatekeeper
+          # WORSE than the ad-hoc seal. Delete this line (and set CSC_LINK /
+          # CSC_KEY_PASSWORD secrets) when a real Developer ID lands.
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: pnpm --filter ./desktop run ${{ matrix.script }}
       # Listed before uploading so a build that produced nothing is visible in
       # the log as an empty directory rather than as a silently short release.
@@ -218,7 +238,8 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           files=(desktop/release/*.exe desktop/release/*.blockmap desktop/release/*.AppImage \
-                 desktop/release/*.deb desktop/release/latest*.yml)
+                 desktop/release/*.deb desktop/release/*.dmg desktop/release/*.zip \
+                 desktop/release/latest*.yml)
           if [ ${#files[@]} -eq 0 ]; then
             echo "no desktop artefacts to upload" >&2
             exit 1

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -55,6 +55,7 @@ pnpm run dev        # build, then run it
 # installers (unsigned)
 pnpm run dist:win
 pnpm run dist:linux     # .deb + AppImage
+pnpm run dist:mac       # .dmg + .zip — host arch (arm64 on Apple Silicon), ad-hoc sealed
 ```
 
 `FILEX_CLI_BIN=<path>` points `fetch-cli.mjs` at an already-built CLI instead of
@@ -102,6 +103,22 @@ expose the narrowest surface that works. Tokens live in the OS keychain.
 Releases are **unsigned** by design for now — Windows SmartScreen and macOS
 Gatekeeper will warn. A code-signing certificate is a separate, paid decision,
 not a defect.
+
+macOS specifics, because the failure mode there is not a warning but a wall:
+
+- A no-certificate electron-builder output is only *linker-signed*, and macOS
+  26 treats that half-signature on a downloaded app as tampering: **"malware
+  blocked and moved to Trash"**, no override offered. `scripts/adhoc-sign.cjs`
+  (an `afterPack` hook) therefore re-seals the bundle with a deep **ad-hoc**
+  signature, which downgrades the verdict to the honest "unverified developer"
+  dialog.
+- First launch of a downloaded copy: macOS blocks once — open **System
+  Settings → Privacy & Security → Open Anyway** (or right-click → Open on
+  older versions). A locally built copy has no quarantine flag and just opens.
+- **Auto-update is inert on macOS until real signing lands**: Squirrel.Mac
+  refuses to swap an unsigned app. The `zip` target and `latest-mac.yml` ship
+  anyway so the feed is already correct the day a Developer ID certificate
+  (and notarization) arrives — which is the actual fix for all of the above.
 
 ## Packaging traps (each of these shipped once)
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -68,8 +68,20 @@ win:
     - nsis
 mac:
   target:
+    # dmg is the human download; zip is what electron-updater's mac feed
+    # (latest-mac.yml) points at — without it the feed file names an artifact
+    # that does not exist. Auto-update on mac stays INERT until the app is
+    # signed with a real identity (Squirrel.Mac refuses to swap an unsigned
+    # app); the zip ships anyway so the feed is already correct the day a
+    # Developer ID lands.
     - dmg
+    - zip
   category: public.app-category.productivity
+
+# Unsigned macOS builds get a deep ad-hoc re-seal (see the script for why a
+# half-signed bundle reads as MALWARE to macOS 26 while an ad-hoc-sealed one
+# gets the "Open Anyway" path). No-op off macOS and when a real cert is set.
+afterPack: scripts/adhoc-sign.cjs
 
 nsis:
   oneClick: false

--- a/desktop/scripts/adhoc-sign.cjs
+++ b/desktop/scripts/adhoc-sign.cjs
@@ -1,0 +1,37 @@
+// afterPack: give unsigned macOS builds a real (ad-hoc) bundle seal.
+//
+// electron-builder with no certificate SKIPS signing, which leaves the app
+// only "linker-signed": every Mach-O keeps the ad-hoc signature the linker
+// stamped at build time, but the BUNDLE has no seal — Info.plist not bound,
+// no sealed resources. macOS treats that half-signature as tampering, and on
+// macOS 26 a downloaded copy is greeted with "malware blocked and moved to
+// Trash", with no override offered (measured 2026-08-18, filex-desktop-arm64
+// v0.20.2 out of the dmg). A forced deep ad-hoc re-sign is what turns that
+// into the honest "unverified developer" dialog with the System Settings →
+// Open Anyway path. It costs nothing and needs no certificate.
+//
+// ⚠ CommonJS on purpose: desktop/package.json is `"type": "module"`, and
+// electron-builder loads hooks with require(); a .cjs file works under both.
+//
+// Skipped when a real identity is configured (CSC_LINK / CSC_NAME): osx-sign
+// already produced a proper signature and a --force re-sign would replace the
+// Developer ID seal with an ad-hoc one — strictly worse.
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+module.exports = async function adhocSign(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  if (process.env.CSC_LINK || process.env.CSC_NAME) return;
+
+  const app = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`,
+  );
+
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', app], { stdio: 'inherit' });
+  // Verify, so a broken seal fails THIS build instead of a user's first launch.
+  execFileSync('codesign', ['--verify', '--deep', '--strict', app], { stdio: 'inherit' });
+  console.log(`  • ad-hoc sealed ${path.basename(app)} (no certificate — Gatekeeper will show "unverified developer")`);
+};

--- a/desktop/scripts/fetch-cli.mjs
+++ b/desktop/scripts/fetch-cli.mjs
@@ -76,11 +76,19 @@ for (const sub of ['admin', 'web']) {
 }
 
 const goos = platform === 'win32' ? 'windows' : platform;
+// ⚠ GOARCH must follow the HOST, not default to amd64. This used to be
+// `process.env.GOARCH || 'amd64'`, which put an x86_64 sync engine inside an
+// arm64 filex.app: the app itself launched native, then spawned the CLI under
+// Rosetta and macOS 26 greeted every launch with the "Intel-based apps will no
+// longer be supported" deprecation alert (measured 2026-08-18). CI is
+// unaffected — its x64 runners resolve to amd64 exactly as before, and an
+// explicit GOARCH still wins for cross-builds.
+const goarch = process.env.GOARCH || (process.arch === 'arm64' ? 'arm64' : 'amd64');
 try {
   execFileSync('go', ['build', '-trimpath', '-ldflags', '-s -w', '-o', dest, './cmd/filex'], {
     cwd: BACKEND,
     stdio: 'inherit',
-    env: { ...process.env, GOOS: goos, GOARCH: process.env.GOARCH || 'amd64', CGO_ENABLED: '0' },
+    env: { ...process.env, GOOS: goos, GOARCH: goarch, CGO_ENABLED: '0' },
   });
 } catch (err) {
   console.error(

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -12,6 +12,7 @@ const caps = useCapabilitiesStore();
 
 const handingOff = ref(false);
 const handoffCode = ref<string | null>(null);
+const handoffError = ref(false);
 const copied = ref(false);
 
 async function copyCode() {
@@ -39,10 +40,13 @@ onMounted(async () => {
     try {
       handoffCode.value = await completeDesktopHandoff();
     } catch {
-      // Leave the flag up: the panel behind is still usable, and the desktop
-      // app shows its own timeout. Silently continuing would look like nothing
-      // happened at all.
-      handingOff.value = false;
+      // Leave the flag up and SAY it failed. This branch used to drop the
+      // overlay (`handingOff.value = false`) — the exact "looks like nothing
+      // happened at all" its own comment warned about: the user came from the
+      // desktop app, the mint failed, and the browser showed a file manager
+      // with no code and no error. The desktop app still shows its own
+      // timeout; this screen owns telling the user the browser half failed.
+      handoffError.value = true;
     }
   }
 });
@@ -58,7 +62,10 @@ onMounted(async () => {
     data-testid="desktop-handoff"
   >
     <div class="w-full max-w-sm px-6 text-center">
-      <p class="text-sm text-zinc-600 dark:text-zinc-300">{{ $t('desktop.handoff') }}</p>
+      <p v-if="handoffError" class="text-sm text-red-600 dark:text-red-400" data-testid="handoff-error">
+        {{ $t('desktop.handoffError') }}
+      </p>
+      <p v-else class="text-sm text-zinc-600 dark:text-zinc-300">{{ $t('desktop.handoff') }}</p>
       <!-- The code is shown, not hidden behind a failure: a browser silently
            does nothing when no filex:// handler is registered, so there is no
            event to react to. Whoever needs it can copy it into the app. -->

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1008,6 +1008,7 @@
   },
   "desktop": {
     "handoff": "You can return to the desktop app — authorization complete.",
+    "handoffError": "Authorizing the desktop app failed. Close this tab and try signing in from the app again.",
     "codeHint": "If the app did not open, copy this code into its waiting screen:",
     "copy": "Copy",
     "copied": "Copied"

--- a/web/src/locales/tr.json
+++ b/web/src/locales/tr.json
@@ -1008,6 +1008,7 @@
   },
   "desktop": {
     "handoff": "Masaüstü uygulamasına dönebilirsiniz — yetkilendirme tamamlandı.",
+    "handoffError": "Masaüstü uygulaması yetkilendirilemedi. Bu sekmeyi kapatıp uygulamadan tekrar giriş deneyin.",
     "codeHint": "Uygulama açılmadıysa bu kodu bekleme ekranına yapıştırın:",
     "copy": "Kopyala",
     "copied": "Kopyalandı"

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router';
 import { useAuthStore } from '@/stores/auth';
+import { stashDesktopHandoff } from '@/lib/desktopHandoff';
 
 import AdminLayout from '@/components/AdminLayout.vue';
 
@@ -255,6 +256,17 @@ const router = createRouter({
 
 router.beforeEach(async (to) => {
   const auth = useAuthStore();
+
+  // ⚠ Desktop pairing params must be stashed HERE, not only in the login
+  // view. A browser that already has a session never mounts Login.vue — the
+  // dashboard redirect below fires first and destroys the query string, so
+  // the desktop app sat on its waiting screen forever and the browser showed
+  // a file manager with no code and no error. Measured 2026-08-18: pairing
+  // only ever worked from a browser with no session. Stashing before the
+  // first await also beats App.vue's post-fetchMe hasPendingHandoff() check.
+  if (to.name === 'login') {
+    stashDesktopHandoff(to.query.desktop_state, to.query.desktop_challenge);
+  }
 
   // Hydrate session on cold-load before guarding.
   if (!auth.ready) {


### PR DESCRIPTION
Three fixes from a real macOS 26 (Apple Silicon) deployment of filex desktop v0.20.2 against a live multi-tenant server, 2026-08-18. Each was reproduced, root-caused in source, and verified fixed locally.

## 1. `fix(web)`: desktop pairing dies in an already-signed-in browser

**Symptom:** open the app's pairing link in a browser that already has a filex session → file manager appears, no code, no error; the app waits forever. Server logs confirm `POST /api/auth/desktop/complete` is never sent.

**Root cause:** the router guard's "already signed-in users shouldn't see /login" redirect destroys the query string before `Login.vue` can `stashDesktopHandoff()` — the stash only ever ran when the login view actually mounted.

**Fix:** stash `desktop_state`/`desktop_challenge` in `beforeEach`, ahead of the first `await`, so every path into `/login` keeps them. Bonus fix in `App.vue`: the hand-off `catch` used to drop the overlay (the exact "looks like nothing happened at all" its own comment warns about) — it now keeps the overlay and shows a new `desktop.handoffError` string (en + tr).

**Verified:** `vue-tsc --noEmit && vite build` clean.

## 2. `fix(desktop)`: embedded CLI compiled for amd64 on arm64 hosts

**Symptom:** every app launch on an Apple Silicon Mac pops macOS 26's "Intel-based apps will no longer be supported" Rosetta deprecation alert — the .app is arm64, but `Resources/bin/filex` (the sync engine) is x86_64.

**Root cause:** `fetch-cli.mjs` hardcoded `GOARCH: process.env.GOARCH || 'amd64'`.

**Fix:** default GOARCH to the host arch (`process.arch`); explicit `GOARCH` still wins, CI's x64 runners resolve to amd64 exactly as before.

**Verified:** rebuilt — `file build/bin/filex` → `Mach-O 64-bit executable arm64`; alert gone.

## 3. `ci(desktop)`: ship macOS packages — dmg + zip, ad-hoc sealed

**Symptom of shipping nothing:** users build by hand. Symptom of shipping naively: a no-certificate electron-builder .app is only linker-signed (Info.plist not bound, no sealed resources), and macOS 26 greets a downloaded copy with **"malware blocked and moved to Trash"** — no override offered. Measured with a v0.20.2 local dmg.

**Fix:**
- new `afterPack` hook (`scripts/adhoc-sign.cjs`): deep ad-hoc re-seal + `codesign --verify` when no real cert is configured — downgrades the verdict to the honest "unverified developer" dialog with the *Open Anyway* path. No-op off macOS / when `CSC_LINK`/`CSC_NAME` are set.
- `release.yml`: `macos-14` matrix row (pinned — runner arch IS artifact arch), `CSC_IDENTITY_AUTO_DISCOVERY=false` so a stray runner cert can't half-sign, upload `*.dmg` + `*.zip`.
- `electron-builder.yml`: mac targets `dmg` + `zip` — the zip is what `latest-mac.yml` names, so the update feed is correct the day a Developer ID lands (mac auto-update stays inert until then; Squirrel.Mac refuses unsigned swaps).
- README: the whole mac story, including first-launch *Open Anyway*.

**Verified:** local `dist:mac` run — hook logs `ad-hoc sealed filex.app`, `codesign --verify --deep --strict` passes, dmg + zip + `latest-mac.yml` + both blockmaps produced; installed app launches clean.

**The real fix remains a Developer ID certificate + notarization** (removes the dialog and unlocks mac auto-update) — flagged in comments and README as the paid, separate decision it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
