### PR TITLE
sync: visible first runs, safe unpairing, a live pair list — and honest mac updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A pair added while the watcher runs is picked up on the next round.**
+  `filex sync run --watch` read pairs.json once at start, and the desktop app
+  keeps one watcher per account alive for days — so a second folder paired
+  later was silently never synced until the app restarted, while the panel
+  looked exactly as if it were. The watcher now re-reads the pair list between
+  rounds: adds join in, removes drop out. (Reported by the olivov deployment,
+  which hit this whole cluster in one afternoon.)
+
+- **Removing a pair before its first run finished no longer fails.** The
+  baseline file only exists once a first run completes; unpairing earlier hit
+  the missing file and handed the desktop a raw ENOENT error dialog — for a
+  remove that had, in fact, already happened.
+
+- **A failed unpair no longer leaves a ghost watcher.** The desktop only told
+  the supervisor to reconcile after a successful remove, so the error above
+  left a `filex sync run --watch` process syncing a pair that was already gone
+  from pairs.json — measurably listing the server every 30 seconds, and
+  unstoppable from the UI. Reconciliation now runs whether or not the remove
+  threw.
+
+- **The ad-hoc sealed macOS build tells the truth about updates.** Squirrel.Mac
+  refuses to swap an app without a Developer ID signature, and electron-updater
+  only finds that out after downloading — so "Check now" announced a version
+  about to install itself, then fell to a permanent "could not check for
+  updates". When the build's own signature says self-update cannot work, the
+  app now skips the download entirely, reads the update feed directly, and
+  offers the honest thing: the new version's number and a Download button.
+
+### Added
+
+- **Sync progress is visible while it happens — including under `--quiet`.**
+  The engine reports phases now (inventory counts while the server tree is
+  listed folder by folder, `transfer: 12/345`, settling), and the CLI prints
+  them even in quiet mode, which is how the desktop app runs it. A large first
+  sync used to spend its entire inventory phase — minutes, on a big tree —
+  printing nothing at all, and looked broken enough to cancel; that cancel is
+  exactly the path into the two unpair bugs above.
+
 ## [0.21.6] - 2026-08-19
 
 ### Changed

--- a/backend/cmd/filex/sync.go
+++ b/backend/cmd/filex/sync.go
@@ -10,9 +10,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/brf-tech/filex/backend/internal/cliclient"
 	"github.com/brf-tech/filex/backend/internal/filesync"
+	"github.com/spf13/cobra"
 )
 
 // apiAdapter bridges the REST client to the narrow interface the sync engine
@@ -210,7 +210,7 @@ func syncRunCmd(opts *clientOpts) *cobra.Command {
 				return fmt.Errorf("no folders are paired; add one with `filex sync add`")
 			}
 
-			run := func() error {
+			run := func(pairs []filesync.Pair) error {
 				for _, p := range pairs {
 					// ⚠ One token cannot speak for two servers. The desktop app
 					// runs one process per signed-in account and filters here;
@@ -227,6 +227,11 @@ func syncRunCmd(opts *clientOpts) *cobra.Command {
 						continue
 					}
 					eng := &filesync.Engine{Pair: p, API: apiAdapter{api}, Store: st}
+					// Progress prints even with --quiet. The desktop app starts
+					// this command with --quiet and mirrors the LAST stdout line
+					// into its panel; without these lines a big first sync spent
+					// its whole inventory phase looking dead.
+					eng.Progress = func(s string) { fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", p.ID, s) }
 					if !quietOut {
 						eng.Log = func(s string) { fmt.Fprintln(cmd.OutOrStdout(), s) }
 					}
@@ -241,17 +246,26 @@ func syncRunCmd(opts *clientOpts) *cobra.Command {
 			}
 
 			if watch <= 0 {
-				return run()
+				return run(pairs)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Watching %d pair(s); checking every %s. Ctrl-C to stop.\n", len(pairs), watch)
 			for {
-				if err := run(); err != nil {
+				if err := run(pairs); err != nil {
 					return err
 				}
 				select {
 				case <-cmd.Context().Done():
 					return nil
 				case <-time.After(watch):
+				}
+				// Re-read between rounds. pairs.json is edited by OTHER
+				// processes — the desktop app writes it while this watcher
+				// runs — and the old one-time load meant a pair added after
+				// start was silently never synced until the next restart,
+				// while a removed one kept going. The file is tiny; the
+				// re-read costs nothing.
+				if pairs, err = st.LoadPairs(); err != nil {
+					return fmt.Errorf("re-read pairs: %w", err)
 				}
 			}
 		},
@@ -271,7 +285,7 @@ func printPlan(cmd *cobra.Command, api *cliclient.Client, st *filesync.Store, p 
 	if err != nil {
 		return err
 	}
-	remote, err := filesync.WalkRemote(cmd.Context(), apiAdapter{api}, p.Remote)
+	remote, err := filesync.WalkRemote(cmd.Context(), apiAdapter{api}, p.Remote, nil)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/filesync/engine.go
+++ b/backend/internal/filesync/engine.go
@@ -59,6 +59,14 @@ type Engine struct {
 	TrashDays int
 	// Log receives one line per action. Optional.
 	Log func(string)
+	// Progress receives one short status line per phase — inventory counts,
+	// transfer counts, settling — and stays on even when the per-action Log
+	// is silenced. The desktop app runs the engine with --quiet and mirrors
+	// the last stdout line into its panel; before this hook a large first
+	// sync spent its whole inventory phase (minutes of per-folder listings)
+	// printing nothing, and looked dead enough that people cancelled it.
+	// Optional.
+	Progress func(string)
 	// Now is injectable for tests.
 	Now func() time.Time
 }
@@ -73,6 +81,28 @@ func (e *Engine) now() time.Time {
 func (e *Engine) logf(format string, a ...any) {
 	if e.Log != nil {
 		e.Log(fmt.Sprintf(format, a...))
+	}
+}
+
+func (e *Engine) progressf(format string, a ...any) {
+	if e.Progress != nil {
+		e.Progress(fmt.Sprintf(format, a...))
+	}
+}
+
+// remoteProgress emits a listing count for one remote walk, throttled so a
+// huge tree reports every 25 folders rather than every one.
+func (e *Engine) remoteProgress(phase string) func(dirs, items int) {
+	if e.Progress == nil {
+		return nil
+	}
+	next := 1
+	return func(dirs, items int) {
+		if dirs < next {
+			return
+		}
+		next = dirs + 25
+		e.progressf("%s: listed %d server folder(s), %d item(s) so far", phase, dirs, items)
 	}
 }
 
@@ -103,16 +133,20 @@ func (e *Engine) Run(ctx context.Context) (Result, error) {
 		return res, fmt.Errorf("read %s: %w", e.Pair.Local, err)
 	}
 	res.Skipped = skipped
+	e.progressf("inventory: %d item(s) here, listing the server…", len(local))
 
-	remote, err := e.walkRemoteRoot(ctx)
+	remote, err := e.walkRemoteRoot(ctx, "inventory")
 	if err != nil {
 		return res, err
 	}
 
 	actions := Plan(local, remote, base, Options{FirstRun: res.FirstRun, Now: e.now()})
 	res.Planned = len(actions)
+	if res.Planned > 0 {
+		e.progressf("plan: %d change(s) to make", res.Planned)
+	}
 
-	for _, a := range actions {
+	for i, a := range actions {
 		if err := ctx.Err(); err != nil {
 			res.Errors = append(res.Errors, "stopped: "+err.Error())
 			break
@@ -120,9 +154,12 @@ func (e *Engine) Run(ctx context.Context) (Result, error) {
 		if err := e.apply(ctx, a, &res); err != nil {
 			res.Errors = append(res.Errors, fmt.Sprintf("%s %s: %v", a.Kind, a.Rel, err))
 			e.logf("!! %s %s: %v", a.Kind, a.Rel, err)
-			continue
+		} else {
+			res.Applied++
 		}
-		res.Applied++
+		if (i+1)%10 == 0 || i+1 == res.Planned {
+			e.progressf("transfer: %d/%d", i+1, res.Planned)
+		}
 	}
 
 	// Re-snapshot. Using the post-run state rather than assuming the plan
@@ -131,7 +168,7 @@ func (e *Engine) Run(ctx context.Context) (Result, error) {
 	if err != nil {
 		return res, fmt.Errorf("re-read %s: %w", e.Pair.Local, err)
 	}
-	remote2, err := e.walkRemoteRoot(ctx)
+	remote2, err := e.walkRemoteRoot(ctx, "settling")
 	if err != nil {
 		return res, err
 	}
@@ -158,8 +195,8 @@ func (e *Engine) Run(ctx context.Context) (Result, error) {
 // web UI. Pairing is a statement of intent; the folder is part of it. The
 // mkdir is only attempted after a failed listing, so the ordinary case still
 // costs one request.
-func (e *Engine) walkRemoteRoot(ctx context.Context) (Snapshot, error) {
-	snap, err := WalkRemote(ctx, e.API, e.Pair.Remote)
+func (e *Engine) walkRemoteRoot(ctx context.Context, phase string) (Snapshot, error) {
+	snap, err := WalkRemote(ctx, e.API, e.Pair.Remote, e.remoteProgress(phase))
 	if err == nil {
 		return snap, nil
 	}
@@ -170,7 +207,7 @@ func (e *Engine) walkRemoteRoot(ctx context.Context) (Snapshot, error) {
 		return nil, err
 	}
 	e.logf("+> created %s on the server", e.Pair.Remote)
-	return WalkRemote(ctx, e.API, e.Pair.Remote)
+	return WalkRemote(ctx, e.API, e.Pair.Remote, e.remoteProgress(phase))
 }
 
 func (e *Engine) trashDays() int {

--- a/backend/internal/filesync/engine_test.go
+++ b/backend/internal/filesync/engine_test.go
@@ -544,6 +544,50 @@ func TestRemovingAPairLeavesTheFilesAlone(t *testing.T) {
 	}
 }
 
+// The baseline file only exists after a first run has COMPLETED. Unpairing
+// before that (a long first sync the user cancels by removing the pair) used
+// to fail with the raw ENOENT, which the desktop surfaced as an error dialog —
+// and then skipped its own watcher cleanup because the remove "failed".
+func TestRemovingAPairBeforeItsFirstRunSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	s := &Store{Dir: filepath.Join(dir, "state")}
+	p, err := s.AddPair(Pair{Local: filepath.Join(dir, "docs"), Remote: "docs://a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemovePair(p.ID); err != nil {
+		t.Fatalf("removing a never-run pair must not fail: %v", err)
+	}
+	pairs, err := s.LoadPairs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pairs) != 0 {
+		t.Errorf("pair still present after remove: %v", pairs)
+	}
+}
+
+// Progress must speak even when Log is silent: the desktop runs the engine
+// with --quiet and shows only the last stdout line, and the inventory phase
+// of a big first sync otherwise prints nothing for minutes.
+func TestProgressReportsInventoryAndTransfer(t *testing.T) {
+	r := newRig(t)
+	r.srv.files["a.txt"] = []byte("one")
+	r.srv.files["sub/b.txt"] = []byte("two")
+	r.srv.dirs["sub"] = true
+
+	var lines []string
+	r.engine.Progress = func(s string) { lines = append(lines, s) }
+	r.run()
+
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"inventory:", "plan:", "transfer:", "settling:"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("progress lines missing %q:\n%s", want, joined)
+		}
+	}
+}
+
 // A corrupt baseline must degrade to a merge, never to "everything was deleted".
 func TestACorruptBaselineFallsBackToAFirstRun(t *testing.T) {
 	r := newRig(t)

--- a/backend/internal/filesync/snapshot.go
+++ b/backend/internal/filesync/snapshot.go
@@ -126,8 +126,13 @@ func relOf(root, p string) string {
 // remoteRoot is an `adapter://path` prefix; every returned Node.Rel is relative
 // to it, so local and remote snapshots share one key space and the planner can
 // compare them directly.
-func WalkRemote(ctx context.Context, api RemoteLister, remoteRoot string) (Snapshot, error) {
+//
+// progress, when non-nil, is called after each listed directory with the
+// running totals. One network round-trip per folder makes this walk the slow
+// phase of a big first sync, and the only one with nothing else to show.
+func WalkRemote(ctx context.Context, api RemoteLister, remoteRoot string, progress func(dirsListed, itemsSeen int)) (Snapshot, error) {
 	out := Snapshot{}
+	dirsListed := 0
 	// Iterative rather than recursive: a deep tree on the server should not be
 	// able to exhaust this process's stack.
 	queue := []string{""}
@@ -143,6 +148,7 @@ func WalkRemote(ctx context.Context, api RemoteLister, remoteRoot string) (Snaps
 			// A folder that vanished mid-walk is not fatal; the next run sees it.
 			continue
 		}
+		dirsListed++
 		for _, f := range res.Files {
 			if skipNames[f.Basename] {
 				continue
@@ -161,6 +167,9 @@ func WalkRemote(ctx context.Context, api RemoteLister, remoteRoot string) (Snaps
 				Size:      f.Size,
 				ModMillis: f.LastModified,
 			}
+		}
+		if progress != nil {
+			progress(dirsListed, len(out))
 		}
 	}
 	return out, nil

--- a/backend/internal/filesync/store.go
+++ b/backend/internal/filesync/store.go
@@ -129,7 +129,15 @@ func (s *Store) RemovePair(id string) error {
 	if err := s.SavePairs(out); err != nil {
 		return err
 	}
-	return os.Remove(s.path("baseline", id+".json"))
+	// The baseline only appears once a pair's first run has COMPLETED. A pair
+	// removed before that — typically a large first sync the user cancels by
+	// unpairing — has no file here, and that must not read as failure: the
+	// pair is already gone from pairs.json by this line, and callers treat an
+	// error as "the remove failed" and skip their own follow-up.
+	if err := os.Remove(s.path("baseline", id+".json")); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func overlaps(a, b string) bool {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -29,6 +29,7 @@ import {
   shell,
 } from 'electron';
 import electronUpdater from 'electron-updater';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -76,7 +77,7 @@ let pendingAuth: PendingAuth | null = null;
 let quitting = false;
 let supervisor: SyncSupervisor | null = null;
 /** What the updater is doing, as far as the UI is concerned. */
-let updateState: { status: 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'; version?: string; percent?: number; error?: string } = { status: 'idle' };
+let updateState: { status: 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error' | 'manual'; version?: string; percent?: number; error?: string; url?: string } = { status: 'idle' };
 
 protocol.registerSchemesAsPrivileged([
   { scheme: APP_SCHEME, privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true } },
@@ -454,10 +455,83 @@ function pushUpdateState(next: typeof updateState): void {
   for (const w of BrowserWindow.getAllWindows()) w.webContents.send('sync:changed');
 }
 
+// ─── macOS without a Developer ID: honesty instead of a broken swap ───
+//
+// Squirrel.Mac refuses to replace an app that is not Developer-ID signed, and
+// electron-updater only finds that out AFTER the download: the check announced
+// "version X installs itself shortly", the download completed, the swap was
+// refused — and the user was left with a generic "could not check for
+// updates". A permanent, known limitation of the ad-hoc sealed build was being
+// dressed up as a transient error, on every check, forever.
+//
+// So the build's own signature is read once at startup. When it turns out to
+// be ad-hoc, electron-updater is never wired at all — nothing is downloaded
+// that can never be applied — and the same check cadence (and the Settings
+// button) instead reads the static feed's latest-mac.yml directly and says the
+// honest thing: a newer version exists, here is the download.
+
+const MAC_FEED_URL = 'https://filex.sh/desktop/latest-mac.yml';
+
+let macManualUpdates = false;
+
+async function detectMacManualUpdates(): Promise<void> {
+  if (process.platform !== 'darwin' || !app.isPackaged) return;
+  const out = await new Promise<string>((resolve) => {
+    execFile('/usr/bin/codesign', ['-dv', app.getPath('exe')], (err, stdout, stderr) => {
+      // codesign prints the signature details on stderr; an error still
+      // carries them (or means no signature at all, which is also "manual").
+      resolve(String(stderr || stdout || err?.message || ''));
+    });
+  });
+  macManualUpdates = !/Developer ID Application/.test(out);
+}
+
+/** Numeric, segment-wise. Good for x.y.z; anything odd compares equal. */
+function isNewerVersion(candidate: string, current: string): boolean {
+  const a = candidate.split('.').map((n) => parseInt(n, 10) || 0);
+  const b = current.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    if ((a[i] ?? 0) !== (b[i] ?? 0)) return (a[i] ?? 0) > (b[i] ?? 0);
+  }
+  return false;
+}
+
+async function checkFeedForManualUpdate(): Promise<void> {
+  pushUpdateState({ status: 'checking' });
+  try {
+    const res = await net.fetch(MAC_FEED_URL, { signal: AbortSignal.timeout(15_000) });
+    if (!res.ok) throw new Error(`feed answered ${res.status}`);
+    const yml = await res.text();
+    const version = /^version:\s*(\S+)/m.exec(yml)?.[1];
+    if (!version) throw new Error('feed carries no version');
+    if (!isNewerVersion(version, app.getVersion())) {
+      pushUpdateState({ status: 'idle' });
+      return;
+    }
+    // Hand the browser the dmg itself when the feed names one; the plain
+    // downloads directory otherwise.
+    const dmg = /^\s*-\s*url:\s*(\S+\.dmg)\s*$/m.exec(yml)?.[1];
+    const url = dmg
+      ? new URL(dmg, 'https://filex.sh/desktop/').toString()
+      : 'https://filex.sh/desktop/';
+    pushUpdateState({ status: 'manual', version, url });
+  } catch (e) {
+    pushUpdateState({ status: 'error', error: String((e as Error)?.message ?? e).slice(0, 200) });
+  }
+}
+
 function wireAutoUpdate(): void {
   // Unpackaged runs have no updater metadata and would log an error on every
   // check; a machine told not to update must not phone home at all.
   if (!app.isPackaged || process.env.FILEX_NO_UPDATE === '1') return;
+
+  if (macManualUpdates) {
+    // Same cadence as the real updater — but only ever LOOKING. No download
+    // starts on a machine that cannot apply it.
+    setTimeout(() => void checkFeedForManualUpdate(), 30_000);
+    setInterval(() => void checkFeedForManualUpdate(), 6 * 60 * 60 * 1000);
+    return;
+  }
 
   autoUpdater.autoDownload = true;
   // ⚠ The install must happen on quit, not mid-session: the sync engine is a
@@ -652,6 +726,10 @@ function publicState() {
     launchAtLoginSupported: app.isPackaged || process.platform === 'linux',
     appVersion: app.getVersion(),
     update: updateState,
+    // True on a macOS build whose signature cannot carry a self-update
+    // (ad-hoc sealed). Settings swaps its "updates itself" copy for the
+    // honest download story when this is set.
+    updateManualOnly: macManualUpdates,
   };
 }
 
@@ -899,8 +977,19 @@ function wireIpc(): void {
   // "Check now" from Settings — the same check the timer runs.
   ipcMain.handle('update:check', () => {
     if (!app.isPackaged || process.env.FILEX_NO_UPDATE === '1') return publicState();
+    if (macManualUpdates) {
+      void checkFeedForManualUpdate();
+      return publicState();
+    }
     pushUpdateState({ status: 'checking' });
     autoUpdater.checkForUpdates().catch(() => {});
+    return publicState();
+  });
+
+  // Opens the manual download in the browser. Only meaningful on a mac build
+  // that cannot swap itself; the URL comes from the feed, never the renderer.
+  ipcMain.handle('update:download', () => {
+    if (updateState.status === 'manual' && updateState.url) void shell.openExternal(updateState.url);
     return publicState();
   });
 
@@ -956,8 +1045,16 @@ function wireIpc(): void {
   });
 
   ipcMain.handle('sync:remove', async (_e, id: string) => {
-    await removePair(id);
-    await refreshPairs();
+    try {
+      await removePair(id);
+    } finally {
+      // Reconcile EVEN IF the remove threw. The watcher process only re-reads
+      // the pair list when the supervisor restarts it; skipping this on error
+      // left a process syncing a pair that was in fact already gone from
+      // pairs.json — visibly listing the server every 30s until someone killed
+      // it by hand. Measured, not theorised.
+      await refreshPairs();
+    }
     return publicState();
   });
 
@@ -1019,7 +1116,8 @@ if (!app.requestSingleInstanceLock()) {
     });
     wireIpc();
     buildTray();
-    wireAutoUpdate();
+    // The signature check decides WHICH updater to wire, so it runs first.
+    void detectMacManualUpdates().then(wireAutoUpdate);
     // Re-assert the login item on every packaged start. The command stored in
     // the registry is a full path, and an install that MOVES leaves it pointing
     // at nothing — which is what an upgrade from a per-machine install to a

--- a/desktop/src/preload-app.cts
+++ b/desktop/src/preload-app.cts
@@ -40,6 +40,9 @@ contextBridge.exposeInMainWorld('filexApp', {
   // updates — the app keeps itself current; these are the manual affordances.
   checkUpdate: () => ipcRenderer.invoke('update:check'),
   installUpdate: () => ipcRenderer.invoke('update:install'),
+  // Only meaningful on a macOS build that cannot swap itself (ad-hoc seal):
+  // opens the feed's dmg in the browser instead of pretending to self-update.
+  downloadUpdate: () => ipcRenderer.invoke('update:download'),
 
   /** Backs the navigator.share polyfill the page installs. See main.ts. */
   share: (data: unknown) => ipcRenderer.invoke('app:share', data),

--- a/desktop/ui/app.html
+++ b/desktop/ui/app.html
@@ -469,6 +469,11 @@
         'upd.ready':            ['Version {v} installs itself shortly', '{v} sürümü birazdan kendiliğinden kurulacak'],
         'upd.restart':          ['Install it now', 'Şimdi kur'],
         'upd.error':            ['Could not check for updates', 'Güncelleme denetlenemedi'],
+        'upd.manual':           ['Version {v} is out — install it by downloading',
+                                 '{v} sürümü çıktı — indirerek kurun'],
+        'upd.manual_idea':      ['This macOS build is not signed for self-update; new versions install as a fresh download.',
+                                 'Bu macOS paketi kendini güncellemek için imzalı değil; yeni sürümler indirilerek kurulur.'],
+        'upd.download':         ['Download', 'İndir'],
         'upd.dev':              ['Only the installed app updates itself.',
                                  'Yalnızca kurulu uygulama kendini günceller.'],
         'set.on':               ['On', 'Açık'],
@@ -870,19 +875,25 @@
       function updateCard() {
         const u = state.update || { status: 'idle' };
         const supported = state.launchAtLoginSupported !== false; // packaged run
+        // An ad-hoc sealed mac build cannot swap itself; its story is a
+        // download, and pretending otherwise is what this card used to do.
+        const manual = state.updateManualOnly === true;
         let line = T('upd.current');
         if (!supported) line = T('upd.dev');
         else if (u.status === 'checking') line = T('upd.checking');
+        else if (u.status === 'manual') line = T('upd.manual', { v: u.version || '' });
         else if (u.status === 'available') line = T('upd.available', { v: u.version || '' });
         else if (u.status === 'downloading') line = T('upd.downloading', { p: u.percent ?? 0 });
         else if (u.status === 'ready') line = T('upd.ready', { v: u.version || '' });
         else if (u.status === 'error') line = T('upd.error');
         const btn = u.status === 'ready'
           ? `<button class="primary" id="upd-install">${esc(T('upd.restart'))}</button>`
-          : `<button id="upd-check" ${supported ? '' : 'disabled'}>${esc(T('upd.check'))}</button>`;
+          : u.status === 'manual'
+            ? `<button class="primary" id="upd-download">${esc(T('upd.download'))}</button>`
+            : `<button id="upd-check" ${supported ? '' : 'disabled'}>${esc(T('upd.check'))}</button>`;
         return `<div class="card"><div class="between">
             <div><strong>${esc(line)}</strong>
-              <div class="muted">${esc(T('upd.idea'))}</div></div>
+              <div class="muted">${esc(T(manual && supported ? 'upd.manual_idea' : 'upd.idea'))}</div></div>
             ${btn}
           </div></div>`;
       }
@@ -947,6 +958,8 @@
         });
         const updInstall = $('#upd-install', el);
         if (updInstall) updInstall.addEventListener('click', () => window.filexApp.installUpdate());
+        const updDownload = $('#upd-download', el);
+        if (updDownload) updDownload.addEventListener('click', () => window.filexApp.downloadUpdate());
         $('#login-item', el).addEventListener('click', async () => {
           state = await window.filexApp.setSettings({ launchAtLogin: !state.launchAtLogin });
           renderSettings();


### PR DESCRIPTION
Five findings from the olivov deployment's first real day with desktop folder sync (macOS 26, arm64, v0.20.2 — every one re-verified present in v0.21.6 source: `git log v0.20.2..v0.21.6` over `backend/internal/filesync`, `backend/cmd/filex/sync.go`, `desktop/src/sync.ts`, `desktop/src/main.ts` and `desktop/ui` is empty). One user action produced the whole chain: pair the entire store → watch nothing happen for 8+ minutes (D4) → assume it is broken and remove the pair → error dialog (D1) → ghost watcher that keeps syncing the removed pair until killed by hand (D2). Source review then turned up D3 (the dangerous one) and D5.

## What this PR fixes

**D3 — pairs added while the watcher runs were never synced (silent).** `syncRunCmd` loaded `pairs.json` once, outside the watch loop, and the supervisor deliberately does not restart a process that is already running for the account — so the second and third folders a user paired were silently ignored until the app restarted, while the panel looked fine. The user believes that folder is backed up. It is not. → The watch loop now re-reads the pair list between rounds; adds join in, removes drop out. A corrupt `pairs.json` exits the watcher loudly (the supervisor already reports a dead watcher) rather than being ignored.

**D1 — removing a pair before its first run completed threw ENOENT.** `Store.RemovePair` unconditionally `os.Remove`d the baseline file, which only exists after a first *completed* run. The remove had actually succeeded (pairs.json was already rewritten); the dialog was cosmetic — but it also triggered D2. → `fs.ErrNotExist` is now swallowed, anything else still surfaces.

**D2 — a throwing remove skipped supervisor reconciliation → ghost sync process.** `sync:remove` did `await removePair(id); await refreshPairs();` — when the first line threw, no reconcile ran, and the watcher (which keeps the pair list in memory) kept syncing the deleted pair. Measured live: pair removed at 13:41, process still walking the tree at 13:46 (~200 KB of listing traffic per 30s round), no way to stop it from the UI. → `refreshPairs()` now runs in a `finally`.

**D4 — `--quiet` meant a large first sync looked dead.** The desktop launches the engine with `--quiet` and mirrors the last stdout line into its panel — but the engine only ever logged per-action lines, nothing during inventory, and quiet silenced even those. A whole-store first sync sat 8+ minutes in the inventory phase (one listing request per folder, ~5 MB of traffic, zero transfers) with a blank panel. That blankness is what caused the user to cancel into D1→D2. → The engine grew a `Progress` hook (separate from `Log`): inventory counts every 25 listed folders, `plan: N change(s)`, `transfer: i/N` every 10 actions, settling. The CLI prints progress lines *even under `--quiet`*, prefixed with the pair id. No desktop changes needed — the panel already shows the last line.

**D5 — the ad-hoc sealed macOS build promised a self-update it can never deliver.** "Check now" announced "version X installs itself shortly", downloaded the update, then Squirrel.Mac refused the unsigned swap and the flow fell into the generic "could not check for updates" — a known permanent limitation (v0.20.3 release notes state it) presented as a transient error, forever. → At startup the app reads its own signature once (`codesign -dv`, looking for a Developer ID authority). When self-update cannot work: the auto-updater is never wired (nothing is downloaded that can never be applied), the same 30s-delay/6h-interval cadence instead reads `latest-mac.yml` from the static feed directly, and Settings shows the honest state — "Version X is out — install it by downloading" with a Download button that opens the feed's dmg in the browser. The "updates itself in the background" copy is swapped for an honest line too (en + tr strings included). A properly Developer-ID-signed build behaves exactly as before.

## Tests

- `TestRemovingAPairBeforeItsFirstRunSucceeds` — D1.
- `TestProgressReportsInventoryAndTransfer` — D4 (asserts inventory/plan/transfer/settling lines with `Log` unset).
- Full `go vet` + `go test -race` green on `internal/filesync` and `cmd/filex`; desktop `tsc --noEmit` green. (`internal/plugin`'s `TestBinaryPluginRoundTrip` fails on my machine on a clean checkout too — pre-existing, untouched here.)
- CHANGELOG entries under `[Unreleased]`.

Not included: a real fix for macOS auto-update (Developer ID + notarization — a paid, operator-level decision), and the File Provider "online-only" idea; both stay on our wishlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
